### PR TITLE
630:P2 Issue 7: Extract magic numbers in bash-tools.exec.ts

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -105,17 +105,21 @@ function validateHostEnv(env: Record<string, string>): void {
     }
   }
 }
+const MAX_OUTPUT_CHARS_LIMIT = 200_000;
+const MIN_OUTPUT_CHARS = 1_000;
+const DEFAULT_PTY_COLS = 120;
+const DEFAULT_PTY_ROWS = 30;
 const DEFAULT_MAX_OUTPUT = clampNumber(
   readEnvInt("PI_BASH_MAX_OUTPUT_CHARS"),
-  200_000,
-  1_000,
-  200_000,
+  MAX_OUTPUT_CHARS_LIMIT,
+  MIN_OUTPUT_CHARS,
+  MAX_OUTPUT_CHARS_LIMIT,
 );
 const DEFAULT_PENDING_MAX_OUTPUT = clampNumber(
   readEnvInt("OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS"),
-  200_000,
-  1_000,
-  200_000,
+  MAX_OUTPUT_CHARS_LIMIT,
+  MIN_OUTPUT_CHARS,
+  MAX_OUTPUT_CHARS_LIMIT,
 );
 const DEFAULT_PATH =
   process.env.PATH ?? "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
@@ -489,8 +493,8 @@ async function runExecProcess(opts: {
         cwd: opts.workdir,
         env: opts.env,
         name: process.env.TERM ?? "xterm-256color",
-        cols: 120,
-        rows: 30,
+        cols: DEFAULT_PTY_COLS,
+        rows: DEFAULT_PTY_ROWS,
       });
       stdin = {
         destroyed: false,


### PR DESCRIPTION
## Summary
Extracts repeated magic numbers (`200_000`, `1_000`, `120`, `30`) into named constants at module scope, improving readability and maintainability.

Closes #27

## Changes
- Extracted `MAX_OUTPUT_CHARS_LIMIT`, `MIN_OUTPUT_CHARS`, `DEFAULT_PTY_COLS`, `DEFAULT_PTY_ROWS`
- Replaced all inline usages with the named constants

## Verification
- `pnpm build` — type-check passes
- `pnpm test` — all bash-tools tests pass

## Evidence
- Before: 4 occurrences of `200_000` and 2 of `1_000` as raw literals
- After: Single constant definition for each, referenced by name