### PR TITLE
630:P2 Issue 8: Replace any casts with typed interface in tools-invoke-http.ts

### DIFF
--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -31,6 +31,12 @@ import {
 } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
 
+type ExecutableToolLike = {
+  name: string;
+  parameters?: unknown;
+  execute?: (id: string, args: unknown) => Promise<unknown>;
+};
+
 const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
 const MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
 
@@ -230,15 +236,13 @@ export async function handleToolsInvokeHttpRequest(
 
   const coreToolNames = new Set(
     allTools
-      // oxlint-disable-next-line typescript/no-explicit-any
-      .filter((tool) => !getPluginToolMeta(tool as any))
+      .filter((tool) => !getPluginToolMeta(tool as ExecutableToolLike))
       .map((tool) => normalizeToolName(tool.name))
       .filter(Boolean),
   );
   const pluginGroups = buildPluginToolGroups({
     tools: allTools,
-    // oxlint-disable-next-line typescript/no-explicit-any
-    toolMeta: (tool) => getPluginToolMeta(tool as any),
+      toolMeta: (tool) => getPluginToolMeta(tool as ExecutableToolLike),
   });
   const resolvePolicy = (policy: typeof profilePolicy, label: string) => {
     const resolved = stripPluginOnlyAllowlist(policy, pluginGroups, coreToolNames);
@@ -308,13 +312,11 @@ export async function handleToolsInvokeHttpRequest(
 
   try {
     const toolArgs = mergeActionIntoArgsIfSupported({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      toolSchema: (tool as any).parameters,
+      toolSchema: (tool as ExecutableToolLike).parameters,
       action,
       args,
     });
-    // oxlint-disable-next-line typescript/no-explicit-any
-    const result = await (tool as any).execute?.(`http-${Date.now()}`, toolArgs);
+    const result = await (tool as ExecutableToolLike).execute?.(`http-${Date.now()}`, toolArgs);
     sendJson(res, 200, { ok: true, result });
   } catch (err) {
     sendJson(res, 400, {


### PR DESCRIPTION
## Summary
Replaces four unsafe `as any` casts with a properly typed `ExecutableToolLike` interface, improving type safety in the HTTP tool invocation path.

Closes #28

## Changes
- Added `ExecutableToolLike` type with `name`, `parameters`, and `execute` fields
- Replaced all 4 `(tool as any)` casts with `(tool as ExecutableToolLike)`
- Removed 4 oxlint-disable comments that are no longer needed

## Verification
- `pnpm build` — type-check passes
- `pnpm test` — all gateway tests pass

## Evidence
- Before: 4 `as any` casts with lint suppression comments in security-sensitive code
- After: Properly typed casts with no lint suppression needed