### PR TITLE
630:P3 #65 -- introduce MigrationCommand + Invoker for legacy migrations

### DIFF
--- a/src/config/legacy.shared.test.ts
+++ b/src/config/legacy.shared.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  adaptLegacyMigration,
+  type LegacyConfigMigration,
+  type MigrationCommand,
+  runMigrations,
+} from "./legacy.shared.js";
+
+describe("MigrationCommand + runMigrations Invoker (#65)", () => {
+  it("returns null next when nothing applied", () => {
+    const noop: MigrationCommand = {
+      id: "noop",
+      describe: "Does nothing",
+      execute: () => ({ applied: false, changes: [] }),
+    };
+    const result = runMigrations({ a: 1 }, [noop]);
+    expect(result.next).toBeNull();
+    expect(result.changes).toEqual([]);
+  });
+
+  it("returns mutated next + change descriptions when at least one applies", () => {
+    const renameAToB: MigrationCommand = {
+      id: "rename-a-to-b",
+      describe: "Renames key a to b",
+      execute(ctx) {
+        if (typeof ctx.raw.a !== "undefined") {
+          ctx.raw.b = ctx.raw.a;
+          delete ctx.raw.a;
+          return { applied: true, changes: ["Renamed a to b"] };
+        }
+        return { applied: false, changes: [] };
+      },
+    };
+    const result = runMigrations({ a: 42 }, [renameAToB]);
+    expect(result.next).toEqual({ b: 42 });
+    expect(result.changes).toEqual(["Renamed a to b"]);
+  });
+
+  it("does not mutate the input config (clones first)", () => {
+    const renameInPlace: MigrationCommand = {
+      id: "in-place",
+      describe: "Test",
+      execute(ctx) {
+        ctx.raw.touched = true;
+        return { applied: true, changes: ["touched"] };
+      },
+    };
+    const input = { x: 1 };
+    runMigrations(input, [renameInPlace]);
+    expect(input).toEqual({ x: 1 });
+    expect(input as Record<string, unknown>).not.toHaveProperty("touched");
+  });
+
+  it("runs commands in order and aggregates all change descriptions", () => {
+    const trace: string[] = [];
+    const make = (id: string): MigrationCommand => ({
+      id,
+      describe: id,
+      execute() {
+        trace.push(id);
+        return { applied: true, changes: [`from-${id}`] };
+      },
+    });
+    const result = runMigrations({}, [make("first"), make("second"), make("third")]);
+    expect(trace).toEqual(["first", "second", "third"]);
+    expect(result.changes).toEqual(["from-first", "from-second", "from-third"]);
+  });
+
+  it("returns empty result for non-object input", () => {
+    expect(runMigrations(null, [])).toEqual({ next: null, changes: [] });
+    expect(runMigrations("not an object", [])).toEqual({ next: null, changes: [] });
+    expect(runMigrations(undefined, [])).toEqual({ next: null, changes: [] });
+  });
+
+  it("adaptLegacyMigration preserves apply() semantics", () => {
+    const legacy: LegacyConfigMigration = {
+      id: "legacy-1",
+      describe: "Legacy migration",
+      apply(raw, changes) {
+        if (raw.flag === true) {
+          raw.flag = "yes";
+          changes.push("Coerced flag");
+        }
+      },
+    };
+    const command = adaptLegacyMigration(legacy);
+    expect(command.id).toBe("legacy-1");
+    expect(command.describe).toBe("Legacy migration");
+
+    const ctxApplied = { raw: { flag: true } as Record<string, unknown> };
+    expect(command.execute(ctxApplied)).toEqual({ applied: true, changes: ["Coerced flag"] });
+    expect(ctxApplied.raw.flag).toBe("yes");
+
+    const ctxSkipped = { raw: { flag: false } as Record<string, unknown> };
+    expect(command.execute(ctxSkipped)).toEqual({ applied: false, changes: [] });
+    expect(ctxSkipped.raw.flag).toBe(false);
+  });
+});

--- a/src/config/legacy.shared.ts
+++ b/src/config/legacy.shared.ts
@@ -10,6 +10,89 @@ export type LegacyConfigMigration = {
   apply: (raw: Record<string, unknown>, changes: string[]) => void;
 };
 
+// 630:P3 Issue #65 -- Command pattern.
+//
+// A LegacyConfigMigration is conceptually a Command: it has an id
+// (handle), a describe (human label), and an apply method that mutates
+// the receiver (the raw config). Today, however, each migration writes
+// its change descriptions into a shared `changes: string[]` passed by
+// the runner -- the Spaghetti Code shape that #65 targets, because the
+// "did this command apply anything?" signal is smeared across the
+// callee mutating the caller's array.
+//
+// MigrationCommand is the typed Command interface. execute() takes a
+// MigrationContext (per-invocation state, isolated to this command)
+// and returns a structured MigrationResult that the Invoker aggregates.
+// Adapters below let the Invoker run either an old-style
+// LegacyConfigMigration or a new MigrationCommand uniformly, so the
+// existing migration objects keep working unchanged. New migrations
+// can be authored as MigrationCommands directly, which is what the
+// follow-up consolidation (Section 7.3 of the Part-1 report) targets.
+
+export type MigrationContext = {
+  /** The mutable raw config the command may rewrite in place. */
+  raw: Record<string, unknown>;
+};
+
+export type MigrationResult = {
+  /** True iff the command actually mutated `raw`. */
+  applied: boolean;
+  /** Human-readable change descriptions to surface to the user. */
+  changes: string[];
+};
+
+export type MigrationCommand = {
+  id: string;
+  describe: string;
+  execute(ctx: MigrationContext): MigrationResult;
+};
+
+/**
+ * Adapt a legacy { id, describe, apply } migration to the
+ * MigrationCommand interface. apply() pushes its change descriptions
+ * into a per-invocation array we own, so the Invoker can decide whether
+ * the command did anything based on the array length.
+ */
+export function adaptLegacyMigration(legacy: LegacyConfigMigration): MigrationCommand {
+  return {
+    id: legacy.id,
+    describe: legacy.describe,
+    execute(ctx) {
+      const changes: string[] = [];
+      legacy.apply(ctx.raw, changes);
+      return { applied: changes.length > 0, changes };
+    },
+  };
+}
+
+/**
+ * Invoker: runs the given commands in order against a freshly cloned
+ * copy of `raw`, aggregates their results, and returns the final
+ * mutated config (or null if nothing changed).
+ */
+export function runMigrations(
+  raw: unknown,
+  commands: ReadonlyArray<MigrationCommand>,
+): { next: Record<string, unknown> | null; changes: string[] } {
+  if (!raw || typeof raw !== "object") {
+    return { next: null, changes: [] };
+  }
+  const ctx: MigrationContext = {
+    raw: structuredClone(raw) as Record<string, unknown>,
+  };
+  const allChanges: string[] = [];
+  for (const command of commands) {
+    const result = command.execute(ctx);
+    if (result.applied) {
+      allChanges.push(...result.changes);
+    }
+  }
+  if (allChanges.length === 0) {
+    return { next: null, changes: [] };
+  }
+  return { next: ctx.raw, changes: allChanges };
+}
+
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === "object" && !Array.isArray(value));
 

--- a/src/config/legacy.ts
+++ b/src/config/legacy.ts
@@ -1,6 +1,7 @@
 import type { LegacyConfigIssue } from "./types.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy.migrations.js";
 import { LEGACY_CONFIG_RULES } from "./legacy.rules.js";
+import { adaptLegacyMigration, runMigrations } from "./legacy.shared.js";
 
 export function findLegacyConfigIssues(raw: unknown): LegacyConfigIssue[] {
   if (!raw || typeof raw !== "object") {
@@ -24,20 +25,16 @@ export function findLegacyConfigIssues(raw: unknown): LegacyConfigIssue[] {
   return issues;
 }
 
+// 630:P3 Issue #65 -- precompute the adapted Command list once. Each
+// LegacyConfigMigration becomes a MigrationCommand via adaptLegacyMigration.
+const LEGACY_MIGRATION_COMMANDS = LEGACY_CONFIG_MIGRATIONS.map(adaptLegacyMigration);
+
 export function applyLegacyMigrations(raw: unknown): {
   next: Record<string, unknown> | null;
   changes: string[];
 } {
-  if (!raw || typeof raw !== "object") {
-    return { next: null, changes: [] };
-  }
-  const next = structuredClone(raw) as Record<string, unknown>;
-  const changes: string[] = [];
-  for (const migration of LEGACY_CONFIG_MIGRATIONS) {
-    migration.apply(next, changes);
-  }
-  if (changes.length === 0) {
-    return { next: null, changes: [] };
-  }
-  return { next, changes };
+  // 630:P3 Issue #65 -- delegate to the Command-pattern Invoker. The
+  // previous body inlined the clone, the loop, and the change-array
+  // shepherding; runMigrations now owns all of that.
+  return runMigrations(raw, LEGACY_MIGRATION_COMMANDS);
 }


### PR DESCRIPTION
## Summary

Closes #65.

The four files `legacy.migrations.{ts, part-1, part-2, part-3}` declared an array of records of the form `{ id, describe, apply(raw, changes) }`, where each `apply()` pushed change descriptions into a shared `changes` array passed by the runner. The "did this command apply anything?" signal was smeared across the callee mutating the caller's array -- the **Spaghetti Code** shape #65 targets.

## Refactor: Command pattern

`src/config/legacy.shared.ts` adds:

- **`MigrationCommand`** interface -- `{ id, describe, execute(ctx) -> MigrationResult }` where `execute()` is the receiver-mutating action and returns a typed `{ applied: boolean, changes: string[] }`.
- **`MigrationContext`** -- per-invocation state isolated to one command.
- **`runMigrations(raw, commands)`** -- the **Invoker**. Clones `raw` once, runs each command in order, aggregates change descriptions, and returns `{ next, changes }` with `next === null` when nothing applied.
- **`adaptLegacyMigration(legacy)`** -- wraps an existing `LegacyConfigMigration` as a `MigrationCommand` so the four existing migration files keep working unchanged. New migrations can be authored as `MigrationCommand` instances directly.

`src/config/legacy.ts` is migrated to delegate to the Invoker. The previous body inlined the `structuredClone`, the loop, and the change-array shepherding; `runMigrations` now owns all of that.

## Anti-pattern -> design pattern

| | |
|---|---|
| Anti-pattern | Spaghetti Code |
| Pattern | **Command** (Behavioral) |
| Files added | `src/config/legacy.shared.test.ts` (6 tests) |
| Files modified | `src/config/legacy.shared.ts`, `src/config/legacy.ts` |

## Non-goals (from the original issue)

The four-file split (`part-1`/`part-2`/`part-3` + `legacy.migrations.ts`) is intentionally left for a follow-up PR. Authoring new migrations as `MigrationCommand` instances and consolidating the files becomes a one-PR follow-up once the Command surface stabilizes.

## Verification

```
pnpm vitest run src/config/legacy.shared.test.ts \
  src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts \
  src/config/config.legacy-config-detection.accepts-imessage-dmpolicy.test.ts
> Test Files  3 passed (3)
> Tests       59 passed (59)
```

The 6 new `legacy.shared.test.ts` tests cover: no-op result, applied result, input non-mutation (clone), execution order + change aggregation, non-object input safety, and `adaptLegacyMigration` parity. The 53 existing `legacy-config-detection` tests continue to pass, confirming end-to-end migration semantics are preserved.

## Scope

Medium (estimated 60 min in #65 backlog; actual ~50 min).