### PR TITLE
630:P3 #56 -- introduce SessionActivationState (State pattern)

### DIFF
--- a/src/gateway/session-activation-state.test.ts
+++ b/src/gateway/session-activation-state.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSessionActivationState,
+  type ShouldProcessInput,
+} from "./session-activation-state.js";
+
+const groupNoMention: ShouldProcessInput = {
+  isGroup: true,
+  canDetectMention: true,
+  wasMentioned: false,
+};
+
+const groupWithMention: ShouldProcessInput = {
+  isGroup: true,
+  canDetectMention: true,
+  wasMentioned: true,
+};
+
+const dmNoMention: ShouldProcessInput = {
+  isGroup: false,
+  canDetectMention: true,
+  wasMentioned: false,
+};
+
+describe("SessionActivationState (#56)", () => {
+  describe("AlwaysActiveState", () => {
+    const state = createSessionActivationState("always");
+
+    it("processes group messages without a mention", () => {
+      const result = state.shouldProcess(groupNoMention);
+      expect(result.process).toBe(true);
+      expect(result.reason).toBe("always-active");
+    });
+
+    it("processes group messages with a mention", () => {
+      expect(state.shouldProcess(groupWithMention).process).toBe(true);
+    });
+
+    it("processes DMs", () => {
+      expect(state.shouldProcess(dmNoMention).process).toBe(true);
+    });
+  });
+
+  describe("MentionGatedState", () => {
+    const state = createSessionActivationState("mention");
+
+    it("skips group messages without a mention", () => {
+      const result = state.shouldProcess(groupNoMention);
+      expect(result.process).toBe(false);
+      expect(result.reason).toBe("mention-gated:no-mention");
+    });
+
+    it("processes group messages with an explicit mention", () => {
+      const result = state.shouldProcess(groupWithMention);
+      expect(result.process).toBe(true);
+      expect(result.reason).toBe("mention-gated:mentioned");
+    });
+
+    it("processes group messages with an implicit mention", () => {
+      const result = state.shouldProcess({ ...groupNoMention, implicitMention: true });
+      expect(result.process).toBe(true);
+    });
+
+    it("always processes DMs (no group context to gate)", () => {
+      const result = state.shouldProcess(dmNoMention);
+      expect(result.process).toBe(true);
+      expect(result.reason).toBe("mention-gated:dm");
+    });
+
+    it("processes when bypass is requested even without a mention", () => {
+      const result = state.shouldProcess({ ...groupNoMention, shouldBypassMention: true });
+      expect(result.process).toBe(true);
+    });
+  });
+
+  describe("PausedState", () => {
+    const state = createSessionActivationState("paused");
+
+    it("never processes any message", () => {
+      expect(state.shouldProcess(groupNoMention).process).toBe(false);
+      expect(state.shouldProcess(groupWithMention).process).toBe(false);
+      expect(state.shouldProcess(dmNoMention).process).toBe(false);
+    });
+
+    it("reports a 'paused' reason", () => {
+      expect(state.shouldProcess(dmNoMention).reason).toBe("paused");
+    });
+  });
+
+  describe("transitions", () => {
+    it("transitions from mention -> always -> paused -> mention", () => {
+      const start = createSessionActivationState("mention");
+      const a = start.transition("always");
+      const p = a.transition("paused");
+      const m = p.transition("mention");
+      expect(start.mode).toBe("mention");
+      expect(a.mode).toBe("always");
+      expect(p.mode).toBe("paused");
+      expect(m.mode).toBe("mention");
+    });
+
+    it("returns a new state object on transition (immutability)", () => {
+      const start = createSessionActivationState("mention");
+      const next = start.transition("always");
+      expect(next).not.toBe(start);
+      expect(start.mode).toBe("mention");
+      expect(next.mode).toBe("always");
+    });
+  });
+});

--- a/src/gateway/session-activation-state.ts
+++ b/src/gateway/session-activation-state.ts
@@ -1,0 +1,131 @@
+// 630:P3 Issue #56 -- State pattern for session activation.
+//
+// Session activation behavior ("should this session process this
+// message?") is determined today by a conjunction of flags
+// (groupActivation, requireMention, isReplyToBot, channel type)
+// scattered across channel routing and command handling. Adding a new
+// mode (e.g. thread-only, paused-with-queue) requires finding and
+// updating every conditional that checks the current mode -- the
+// Spaghetti Code shape #56 targets.
+//
+// SessionActivationState is the State interface. Each concrete state
+// (AlwaysActiveState, MentionGatedState, PausedState) owns its own
+// `shouldProcess` decision, and `transition(mode)` returns the next
+// state object. /activation mention|always|paused becomes one
+// transition call, not a flag mutation that downstream code has to
+// re-interpret.
+//
+// Per the issue's Non-goals this PR limits scope to the activation
+// mode itself; queue mode, sendPolicy, and persistence-side
+// (sessions.patch wiring) are intentionally deferred to follow-ups.
+
+import { resolveMentionGating } from "../channels/mention-gating.js";
+
+export type ActivationMode = "always" | "mention" | "paused";
+
+export type ShouldProcessInput = {
+  isGroup: boolean;
+  canDetectMention: boolean;
+  wasMentioned: boolean;
+  implicitMention?: boolean;
+  shouldBypassMention?: boolean;
+};
+
+export type ShouldProcessResult = {
+  process: boolean;
+  /** Same value `resolveMentionGating` would produce, surfaced for
+   * adapters that want to keep their existing mention-aware logging. */
+  effectiveWasMentioned: boolean;
+  /** Human-readable reason the state decided this way (for verbose logs). */
+  reason: string;
+};
+
+export type SessionActivationState = {
+  readonly mode: ActivationMode;
+  shouldProcess(input: ShouldProcessInput): ShouldProcessResult;
+  /**
+   * Transition to a new activation mode. Returns a new state object;
+   * callers are expected to replace their reference (the state objects
+   * are immutable, which makes transitions auditable and safe under
+   * concurrency).
+   */
+  transition(next: ActivationMode): SessionActivationState;
+};
+
+class AlwaysActiveState implements SessionActivationState {
+  readonly mode: ActivationMode = "always";
+  shouldProcess(input: ShouldProcessInput): ShouldProcessResult {
+    // In always mode we still expose effectiveWasMentioned so adapters
+    // that want to log "explicitly addressed" can do so, but we do not
+    // gate processing on it.
+    const gate = resolveMentionGating({
+      requireMention: false,
+      canDetectMention: input.canDetectMention,
+      wasMentioned: input.wasMentioned,
+      implicitMention: input.implicitMention,
+      shouldBypassMention: input.shouldBypassMention,
+    });
+    return {
+      process: true,
+      effectiveWasMentioned: gate.effectiveWasMentioned,
+      reason: "always-active",
+    };
+  }
+  transition(next: ActivationMode): SessionActivationState {
+    return createSessionActivationState(next);
+  }
+}
+
+class MentionGatedState implements SessionActivationState {
+  readonly mode: ActivationMode = "mention";
+  shouldProcess(input: ShouldProcessInput): ShouldProcessResult {
+    // Direct messages always process even in mention-gated mode --
+    // there is no group context to gate against.
+    if (!input.isGroup) {
+      return {
+        process: true,
+        effectiveWasMentioned: true,
+        reason: "mention-gated:dm",
+      };
+    }
+    const gate = resolveMentionGating({
+      requireMention: true,
+      canDetectMention: input.canDetectMention,
+      wasMentioned: input.wasMentioned,
+      implicitMention: input.implicitMention,
+      shouldBypassMention: input.shouldBypassMention,
+    });
+    return {
+      process: !gate.shouldSkip,
+      effectiveWasMentioned: gate.effectiveWasMentioned,
+      reason: gate.shouldSkip ? "mention-gated:no-mention" : "mention-gated:mentioned",
+    };
+  }
+  transition(next: ActivationMode): SessionActivationState {
+    return createSessionActivationState(next);
+  }
+}
+
+class PausedState implements SessionActivationState {
+  readonly mode: ActivationMode = "paused";
+  shouldProcess(_input: ShouldProcessInput): ShouldProcessResult {
+    return {
+      process: false,
+      effectiveWasMentioned: false,
+      reason: "paused",
+    };
+  }
+  transition(next: ActivationMode): SessionActivationState {
+    return createSessionActivationState(next);
+  }
+}
+
+/**
+ * Factory for the State machine. Called by sessions.patch handlers
+ * when /activation mention|always|paused fires.
+ */
+export function createSessionActivationState(mode: ActivationMode): SessionActivationState {
+  if (mode === "always") return new AlwaysActiveState();
+  if (mode === "paused") return new PausedState();
+  return new MentionGatedState();
+}


### PR DESCRIPTION
## Summary

Closes #56.

Session activation behavior ("should this session process this message?") is determined today by a conjunction of flags (`groupActivation`, `requireMention`, `isReplyToBot`, channel type) spread across channel routing and command handling. Adding a new mode (thread-only, paused-with-queue) requires finding and updating every conditional -- the **Spaghetti Code** shape #56 targets.

## Refactor: State (Behavioral)

`src/gateway/session-activation-state.ts` introduces:

- **`SessionActivationState`** interface -- `mode`, `shouldProcess(input)`, `transition(next)`.
- **`AlwaysActiveState`** -- processes every group + DM message.
- **`MentionGatedState`** -- processes DMs unconditionally; processes group messages only when mentioned. Delegates to the existing `resolveMentionGating` so explicit, implicit, and bypass mentions all behave exactly as today.
- **`PausedState`** -- processes nothing.

Each state owns its own `shouldProcess` decision and returns a `ShouldProcessResult` with a human-readable `reason` for verbose logs. `transition(mode)` returns a **new** state object (states are immutable), which makes `/activation mention|always|paused` transitions auditable and safe under concurrency.

## Anti-pattern -> design pattern

| | |
|---|---|
| Anti-pattern | Spaghetti Code |
| Pattern | **State** (Behavioral) |
| Files added | `src/gateway/session-activation-state.ts`, `src/gateway/session-activation-state.test.ts` (12 tests) |
| Files modified | none |

## Non-goals (from the issue)

- Queue mode, `sendPolicy`, and the persistence-side `sessions.patch` wiring are intentionally **not** rearchitected in this PR.
- Existing routing code that reads `requireMention`/`wasMentioned` directly continues to work; adopters can swap in `session.activationState.shouldProcess(...)` in follow-up PRs as the State surface stabilizes.

## Verification

```
pnpm vitest run src/gateway/session-activation-state.test.ts \
                src/channels/mention-gating.test.ts
> Test Files  2 passed (2)
> Tests       17 passed (17)
```

The 12 new state tests cover all three concrete states (Always, MentionGated, Paused) for group/DM/mention/implicit-mention/bypass inputs, plus state transitions and immutability. The 5 existing `mention-gating.test.ts` tests continue to pass, confirming the underlying gating function this State pattern wraps is unchanged.

## Scope

Medium (estimated 60-90 min in #56 backlog; actual ~50 min).