### PR TITLE
630:P3 #59 -- introduce IMessageChannelAdapter (Adapter as isolation layer)

### DIFF
--- a/src/imessage-adapter.test.ts
+++ b/src/imessage-adapter.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config/config.js";
+import { imessageStartupWarning, selectIMessageAdapter } from "./imessage-adapter.js";
+
+const blueOnly = (): OpenClawConfig => ({
+  channels: {
+    bluebubbles: { serverUrl: "http://example", password: "hunter2" },
+  } as OpenClawConfig["channels"],
+});
+
+const legacyOnly = (): OpenClawConfig => ({
+  channels: {
+    imessage: { enabled: true, cliPath: "imsg" } as OpenClawConfig["channels"]["imessage"],
+  } as OpenClawConfig["channels"],
+});
+
+const both = (): OpenClawConfig => ({
+  channels: {
+    bluebubbles: { serverUrl: "http://example", password: "hunter2" },
+    imessage: { enabled: true, cliPath: "imsg" } as OpenClawConfig["channels"]["imessage"],
+  } as OpenClawConfig["channels"],
+});
+
+const neither = (): OpenClawConfig => ({});
+
+describe("selectIMessageAdapter (#59)", () => {
+  it("returns the BlueBubbles adapter when BlueBubbles is configured", () => {
+    const adapter = selectIMessageAdapter(blueOnly());
+    expect(adapter?.backend).toBe("bluebubbles");
+    expect(adapter?.deprecationWarning()).toBeNull();
+  });
+
+  it("returns the legacy adapter when only legacy iMessage is configured", () => {
+    const adapter = selectIMessageAdapter(legacyOnly());
+    expect(adapter?.backend).toBe("legacy-imsg");
+    expect(adapter?.deprecationWarning()).toMatch(/deprecated/i);
+    expect(adapter?.deprecationWarning()).toMatch(/bluebubbles/i);
+  });
+
+  it("prefers BlueBubbles over legacy when both are configured", () => {
+    const adapter = selectIMessageAdapter(both());
+    expect(adapter?.backend).toBe("bluebubbles");
+    expect(adapter?.deprecationWarning()).toBeNull();
+  });
+
+  it("returns null when neither backend is configured", () => {
+    expect(selectIMessageAdapter(neither())).toBeNull();
+  });
+
+  it("ignores BlueBubbles when serverUrl or password is missing", () => {
+    const onlyUrl: OpenClawConfig = {
+      channels: { bluebubbles: { serverUrl: "http://x" } } as OpenClawConfig["channels"],
+    };
+    expect(selectIMessageAdapter(onlyUrl)).toBeNull();
+    const onlyPw: OpenClawConfig = {
+      channels: { bluebubbles: { password: "x" } } as OpenClawConfig["channels"],
+    };
+    expect(selectIMessageAdapter(onlyPw)).toBeNull();
+  });
+
+  it("treats explicit channels.imessage.enabled === false as not configured", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        imessage: { enabled: false, cliPath: "imsg" } as OpenClawConfig["channels"]["imessage"],
+      } as OpenClawConfig["channels"],
+    };
+    expect(selectIMessageAdapter(cfg)).toBeNull();
+  });
+});
+
+describe("imessageStartupWarning (#59)", () => {
+  it("returns a migration suggestion when the legacy backend is selected", () => {
+    expect(imessageStartupWarning(legacyOnly())).toMatch(/migrate to channels\.bluebubbles/i);
+  });
+
+  it("returns null when BlueBubbles is selected", () => {
+    expect(imessageStartupWarning(blueOnly())).toBeNull();
+  });
+
+  it("returns null when no backend is configured", () => {
+    expect(imessageStartupWarning(neither())).toBeNull();
+  });
+});

--- a/src/imessage-adapter.ts
+++ b/src/imessage-adapter.ts
@@ -1,0 +1,128 @@
+// 630:P3 Issue #59 -- Adapter pattern as isolation layer for the
+// legacy iMessage (imsg) integration vs. the recommended BlueBubbles
+// integration.
+//
+// OpenClaw ships two iMessage paths: BlueBubbles ("recommended") and
+// the legacy `imsg` channel ("legacy macOS-only integration"). Today
+// the gateway and channel docs treat both as parallel top-level
+// configurations -- the Boat Anchor / Dead Code shape #59 targets:
+// the legacy code keeps shipping, keeps consuming startup checks for
+// users who never use it, and keeps confusing new contributors.
+//
+// Per the issue's Non-goals we explicitly do NOT delete the legacy
+// integration -- that is a future deprecation decision. Instead we
+// wrap both paths behind a common IMessageChannelAdapter so callers
+// reason about "the iMessage channel" rather than "imessage vs
+// bluebubbles". The legacy adapter exposes a non-null
+// deprecationWarning() so gateway startup can log a clear migration
+// suggestion. selectIMessageAdapter(cfg) is the small Factory that
+// picks the right adapter based on what the user has configured.
+
+import type { OpenClawConfig } from "./config/config.js";
+
+/**
+ * The kind of underlying iMessage backend an adapter wraps.
+ */
+export type IMessageBackendKind = "bluebubbles" | "legacy-imsg";
+
+/**
+ * Common surface shared by both iMessage backends. Today this is
+ * intentionally narrow -- just the metadata and "is this configured"
+ * decision the gateway needs at startup. Adopting the Adapter for
+ * inbound/outbound dispatch is left for follow-ups so this PR stays
+ * non-breaking for the existing channel-plugin pipeline.
+ */
+export type IMessageChannelAdapter = {
+  /** Stable identifier of the backend wrapped by this adapter. */
+  readonly backend: IMessageBackendKind;
+  /** Display name suitable for status output. */
+  readonly displayName: string;
+  /** True iff the user has supplied enough config for this backend. */
+  isConfigured(cfg: OpenClawConfig): boolean;
+  /**
+   * If the wrapped backend is deprecated, returns a human-readable
+   * one-line warning suitable for the gateway startup log; else null.
+   */
+  deprecationWarning(): string | null;
+};
+
+class BlueBubblesAdapter implements IMessageChannelAdapter {
+  readonly backend: IMessageBackendKind = "bluebubbles";
+  readonly displayName = "BlueBubbles (iMessage)";
+  isConfigured(cfg: OpenClawConfig): boolean {
+    const node = (cfg.channels as Record<string, unknown> | undefined)?.bluebubbles;
+    if (!node || typeof node !== "object") {
+      return false;
+    }
+    const record = node as Record<string, unknown>;
+    const serverUrl = typeof record.serverUrl === "string" ? record.serverUrl.trim() : "";
+    const password = typeof record.password === "string" ? record.password.trim() : "";
+    return serverUrl.length > 0 && password.length > 0;
+  }
+  deprecationWarning(): string | null {
+    return null;
+  }
+}
+
+class LegacyIMessageAdapter implements IMessageChannelAdapter {
+  readonly backend: IMessageBackendKind = "legacy-imsg";
+  readonly displayName = "iMessage (legacy imsg)";
+  isConfigured(cfg: OpenClawConfig): boolean {
+    const node = cfg.channels?.imessage;
+    if (!node || typeof node !== "object") {
+      return false;
+    }
+    const record = node as Record<string, unknown>;
+    if (record.enabled === false) {
+      return false;
+    }
+    const cliPath = typeof record.cliPath === "string" ? record.cliPath.trim() : "";
+    const dbPath = typeof record.dbPath === "string" ? record.dbPath.trim() : "";
+    const accounts =
+      record.accounts && typeof record.accounts === "object"
+        ? (record.accounts as Record<string, unknown>)
+        : null;
+    const hasAccount = accounts ? Object.keys(accounts).length > 0 : false;
+    return cliPath.length > 0 || dbPath.length > 0 || hasAccount || record.enabled === true;
+  }
+  deprecationWarning(): string | null {
+    return (
+      "channels.imessage (legacy imsg) is deprecated; please migrate to channels.bluebubbles. " +
+      "See https://docs.openclaw.ai/channels/bluebubbles for the recommended setup."
+    );
+  }
+}
+
+/**
+ * Factory: pick the iMessage adapter for this config.
+ *
+ * Selection rules:
+ * 1. If BlueBubbles is configured, return it (recommended path) and
+ *    surface no deprecation warning regardless of legacy state.
+ * 2. Else if the legacy imsg path is configured, return the legacy
+ *    adapter (its deprecationWarning() is non-null).
+ * 3. Else return null -- no iMessage backend is in use.
+ */
+export function selectIMessageAdapter(cfg: OpenClawConfig): IMessageChannelAdapter | null {
+  const blue = new BlueBubblesAdapter();
+  if (blue.isConfigured(cfg)) {
+    return blue;
+  }
+  const legacy = new LegacyIMessageAdapter();
+  if (legacy.isConfigured(cfg)) {
+    return legacy;
+  }
+  return null;
+}
+
+/**
+ * Convenience helper for gateway startup: returns a message to log if
+ * the chosen adapter is deprecated, or null otherwise. Centralizing
+ * this here means the gateway startup code never has to know the
+ * difference between bluebubbles and legacy-imsg internally.
+ */
+export function imessageStartupWarning(cfg: OpenClawConfig): string | null {
+  const adapter = selectIMessageAdapter(cfg);
+  if (!adapter) return null;
+  return adapter.deprecationWarning();
+}


### PR DESCRIPTION
## Summary

Closes #59.

OpenClaw ships two iMessage paths: BlueBubbles ("recommended") and the legacy `imsg` channel ("legacy macOS-only integration"). Today the gateway and channel docs treat both as parallel top-level configurations -- the **Boat Anchor / Dead Code** shape #59 targets: legacy code keeps shipping, keeps consuming startup checks for users who never use it, and keeps confusing new contributors.

## Refactor: Adapter (Structural) as isolation layer

Per the issue's Non-goals we explicitly do **not** delete the legacy integration -- that is a future deprecation decision. Instead we wrap both paths behind a small common interface in a new `src/imessage-adapter.ts`:

```ts
export type IMessageChannelAdapter = {
  readonly backend: "bluebubbles" | "legacy-imsg";
  readonly displayName: string;
  isConfigured(cfg: OpenClawConfig): boolean;
  deprecationWarning(): string | null;
};

export function selectIMessageAdapter(cfg: OpenClawConfig): IMessageChannelAdapter | null;
export function imessageStartupWarning(cfg: OpenClawConfig): string | null;
```

Selection rules:

1. If BlueBubbles is configured (both `serverUrl` and `password` set), return it -- no deprecation warning.
2. Else if legacy `imsg` is configured (`cliPath` / `dbPath` / `accounts` and not explicitly disabled), return the legacy adapter; its `deprecationWarning()` returns a one-line migration suggestion suitable for the gateway startup log.
3. Else return `null`.

This is the "Adapter as isolation layer" pattern from the issue: the legacy code is **wrapped**, not deleted and not spread through the codebase. Adopting the Adapter for inbound / outbound dispatch is left for follow-ups so this PR stays non-breaking for the existing channel-plugin pipeline.

## Anti-pattern -> design pattern

| | |
|---|---|
| Anti-pattern | Boat Anchor / Dead Code |
| Pattern | **Adapter** (Structural) |
| Files added | `src/imessage-adapter.ts`, `src/imessage-adapter.test.ts` (9 tests) |
| Files modified | none |

## Verification

```
pnpm vitest run src/imessage-adapter.test.ts
> Test Files  1 passed (1)
> Tests       9 passed (9)
```

The 9 new tests cover: BlueBubbles selection, legacy selection, BlueBubbles preference when both are configured, the no-config case, partial BlueBubbles config rejection (serverUrl-only / password-only), explicit `enabled === false` rejection for legacy, and three startup-warning shapes (legacy / BlueBubbles / none). **No existing tests are touched** -- the legacy and BlueBubbles channel-plugin definitions are unchanged.

## Scope

Medium (estimated 60-90 min in #59 backlog; actual ~50 min).