### PR TITLE
630:P3 #55 -- introduce DiscordCommandAuthStrategy + migrate DM path

### DIFF
--- a/src/discord/monitor/native-command-auth.test.ts
+++ b/src/discord/monitor/native-command-auth.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyDiscordChannelKind,
+  selectDiscordCommandAuthStrategy,
+  type DiscordAuthInput,
+} from "./native-command-auth.js";
+
+const sender = { id: "user-1", name: "Alice", tag: "alice#0001" };
+
+const baseDmInput: DiscordAuthInput = {
+  sender,
+  dmPolicy: "open",
+  dmEnabled: true,
+  isGroupDm: false,
+  groupDmEnabled: true,
+};
+
+describe("classifyDiscordChannelKind (#55)", () => {
+  it("returns 'dm' for a direct message", () => {
+    expect(classifyDiscordChannelKind({ isDirectMessage: true, isGroupDm: false })).toBe("dm");
+  });
+
+  it("returns 'group-dm' for a group DM", () => {
+    expect(classifyDiscordChannelKind({ isDirectMessage: false, isGroupDm: true })).toBe(
+      "group-dm",
+    );
+  });
+
+  it("returns 'guild' for a guild channel", () => {
+    expect(classifyDiscordChannelKind({ isDirectMessage: false, isGroupDm: false })).toBe("guild");
+  });
+});
+
+describe("DmInteractionAuthorizer (#55)", () => {
+  const strategy = selectDiscordCommandAuthStrategy("dm");
+
+  it("rejects when DMs are globally disabled", async () => {
+    const result = await strategy.authorize({ ...baseDmInput, dmEnabled: false });
+    expect(result).toMatchObject({ allowed: false, reason: "dm-disabled" });
+  });
+
+  it("rejects when dmPolicy is 'disabled'", async () => {
+    const result = await strategy.authorize({ ...baseDmInput, dmPolicy: "disabled" });
+    expect(result).toMatchObject({ allowed: false, reason: "dm-disabled" });
+  });
+
+  it("allows on 'open' policy without checking allow-list", async () => {
+    const result = await strategy.authorize({ ...baseDmInput, dmPolicy: "open" });
+    expect(result).toEqual({ allowed: true, commandAuthorized: true });
+  });
+
+  it("allows when sender is in the DM allow-list under 'allowlist'", async () => {
+    const result = await strategy.authorize({
+      ...baseDmInput,
+      dmPolicy: "allowlist",
+      dmAllowed: true,
+    });
+    expect(result).toEqual({ allowed: true, commandAuthorized: true });
+  });
+
+  it("rejects on 'allowlist' when sender is not allowed", async () => {
+    const result = await strategy.authorize({
+      ...baseDmInput,
+      dmPolicy: "allowlist",
+      dmAllowed: false,
+    });
+    expect(result).toMatchObject({
+      allowed: false,
+      reason: "dm-not-allowlisted",
+      ephemeral: true,
+    });
+  });
+
+  it("starts a pairing flow on 'pairing' when sender not yet permitted", async () => {
+    const startPairing = vi.fn(async () => ({ code: "ABC123", created: true }));
+    const result = await strategy.authorize({
+      ...baseDmInput,
+      dmPolicy: "pairing",
+      dmAllowed: false,
+      startPairing,
+    });
+    expect(startPairing).toHaveBeenCalledWith({ sender });
+    expect(result).toMatchObject({ allowed: false, reason: "dm-pairing-pending", ephemeral: true });
+    if (result.allowed === false) {
+      expect(result.replyMessage).toContain("Pairing code: ABC123");
+      expect(result.replyMessage).toContain("Your Discord user id: user-1");
+    }
+  });
+
+  it("does not re-send a pairing reply on duplicate requests (created=false)", async () => {
+    const startPairing = vi.fn(async () => ({ code: "ZZZ", created: false }));
+    const result = await strategy.authorize({
+      ...baseDmInput,
+      dmPolicy: "pairing",
+      dmAllowed: false,
+      startPairing,
+    });
+    expect(result).toMatchObject({ allowed: false, replyMessage: null });
+  });
+});
+
+describe("GroupDmInteractionAuthorizer (#55)", () => {
+  const strategy = selectDiscordCommandAuthStrategy("group-dm");
+
+  it("rejects when group DMs are disabled", async () => {
+    const result = await strategy.authorize({
+      ...baseDmInput,
+      isGroupDm: true,
+      groupDmEnabled: false,
+    });
+    expect(result).toMatchObject({ allowed: false, reason: "group-dm-disabled" });
+  });
+
+  it("allows when group DMs are enabled", async () => {
+    const result = await strategy.authorize({
+      ...baseDmInput,
+      isGroupDm: true,
+      groupDmEnabled: true,
+    });
+    expect(result).toEqual({ allowed: true, commandAuthorized: true });
+  });
+});
+
+describe("GuildInteractionAuthorizer (#55)", () => {
+  const strategy = selectDiscordCommandAuthStrategy("guild");
+
+  it("returns allowed (placeholder pending follow-up migration of guild path)", async () => {
+    const result = await strategy.authorize(baseDmInput);
+    expect(result).toEqual({ allowed: true, commandAuthorized: true });
+  });
+});

--- a/src/discord/monitor/native-command-auth.ts
+++ b/src/discord/monitor/native-command-auth.ts
@@ -1,0 +1,174 @@
+// 630:P3 Issue #55 -- Strategy pattern for Discord interaction
+// authorization.
+//
+// dispatchDiscordCommandInteraction in native-command.ts is a
+// 360-line procedural function whose largest sub-cluster is the
+// "should this command be allowed for this user/channel?" decision.
+// That decision branches on: channel kind (DM / GroupDM / guild
+// channel / thread), DM policy (open / pairing / allowlist /
+// disabled), guild access groups, owner allow-list, channel allow-
+// list, and per-channel enable flag -- the God Object shape #55
+// targets, with policy and dispatch tangled inside the same
+// procedural function.
+//
+// DiscordCommandAuthStrategy is the Strategy interface. Each concrete
+// Authorizer (DmInteractionAuthorizer, GuildInteractionAuthorizer,
+// GroupDmInteractionAuthorizer) owns its own decision. The dispatcher
+// becomes a thin selector + caller -- adding a new channel type or
+// new auth policy is a new strategy class, not another conditional in
+// the giant function.
+//
+// Per the issue's Non-goals we do NOT unify Discord with
+// Telegram/Slack equivalents and we do NOT redesign the
+// argument-parsing layer. Per the Acceptance Criteria, behavior for
+// existing commands is preserved.
+
+export type DiscordSenderRef = {
+  id: string;
+  name?: string;
+  tag?: string;
+};
+
+export type DiscordChannelKind = "dm" | "group-dm" | "guild";
+
+export type DiscordAuthDecision =
+  | { allowed: true; commandAuthorized: boolean }
+  | {
+      allowed: false;
+      /** Reply message; null when the strategy already responded itself. */
+      replyMessage: string | null;
+      /** Whether the reply should be ephemeral (Discord-specific UX flag). */
+      ephemeral?: boolean;
+      /** Tag the strategy can use for verbose logging. */
+      reason: string;
+    };
+
+/**
+ * The Strategy interface. Each implementation owns its own
+ * "should this interaction proceed?" decision based on the channel
+ * kind it serves.
+ */
+export type DiscordCommandAuthStrategy = {
+  readonly kind: DiscordChannelKind;
+  authorize(input: DiscordAuthInput): Promise<DiscordAuthDecision>;
+};
+
+export type DiscordAuthInput = {
+  sender: DiscordSenderRef;
+  /** Resolved DM policy from discordConfig. */
+  dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
+  /** Whether DMs are globally enabled (discordConfig.dm.enabled). */
+  dmEnabled: boolean;
+  /** Whether the channel is a Group DM. */
+  isGroupDm: boolean;
+  /** discordConfig.dm.groupEnabled ?? true */
+  groupDmEnabled: boolean;
+  /**
+   * Test hook the DM strategy invokes when the sender is not yet
+   * permitted under "pairing" mode. Returns the pairing code so the
+   * caller can render a pairing reply. Strategies must remain pure of
+   * Discord SDK concerns.
+   */
+  startPairing?: (input: { sender: DiscordSenderRef }) => Promise<{
+    code: string;
+    /** True when this is a fresh pairing request (not a duplicate). */
+    created: boolean;
+  }>;
+  /** True when the sender appears in the resolved DM allow-list. */
+  dmAllowed?: boolean;
+};
+
+const DM_DISABLED: DiscordAuthDecision = {
+  allowed: false,
+  replyMessage: "Discord DMs are disabled.",
+  reason: "dm-disabled",
+};
+
+const GROUP_DM_DISABLED: DiscordAuthDecision = {
+  allowed: false,
+  replyMessage: "Discord group DMs are disabled.",
+  reason: "group-dm-disabled",
+};
+
+class DmInteractionAuthorizer implements DiscordCommandAuthStrategy {
+  readonly kind: DiscordChannelKind = "dm";
+  async authorize(input: DiscordAuthInput): Promise<DiscordAuthDecision> {
+    if (!input.dmEnabled || input.dmPolicy === "disabled") {
+      return DM_DISABLED;
+    }
+    if (input.dmPolicy === "open") {
+      return { allowed: true, commandAuthorized: true };
+    }
+    // dmPolicy === "pairing" or "allowlist"
+    if (input.dmAllowed) {
+      return { allowed: true, commandAuthorized: true };
+    }
+    if (input.dmPolicy === "pairing" && input.startPairing) {
+      const { code, created } = await input.startPairing({ sender: input.sender });
+      return {
+        allowed: false,
+        replyMessage: created ? buildPairingReplyText(input.sender.id, code) : null,
+        ephemeral: true,
+        reason: "dm-pairing-pending",
+      };
+    }
+    return {
+      allowed: false,
+      replyMessage: "You are not authorized to use this command.",
+      ephemeral: true,
+      reason: "dm-not-allowlisted",
+    };
+  }
+}
+
+class GroupDmInteractionAuthorizer implements DiscordCommandAuthStrategy {
+  readonly kind: DiscordChannelKind = "group-dm";
+  async authorize(input: DiscordAuthInput): Promise<DiscordAuthDecision> {
+    if (!input.groupDmEnabled) {
+      return GROUP_DM_DISABLED;
+    }
+    return { allowed: true, commandAuthorized: true };
+  }
+}
+
+class GuildInteractionAuthorizer implements DiscordCommandAuthStrategy {
+  readonly kind: DiscordChannelKind = "guild";
+  async authorize(_input: DiscordAuthInput): Promise<DiscordAuthDecision> {
+    // Guild authorization (channel/group-policy/owner-allowlist) lives
+    // in the existing dispatcher today; this strategy is a placeholder
+    // for the follow-up that migrates that path. See #55 Non-goals.
+    return { allowed: true, commandAuthorized: true };
+  }
+}
+
+/**
+ * Strategy factory: pick the authorizer for the resolved channel kind.
+ * Adding a new channel kind (e.g. forum-thread) is a new strategy
+ * class plus one entry here, not a new conditional in the dispatcher.
+ */
+export function selectDiscordCommandAuthStrategy(
+  kind: DiscordChannelKind,
+): DiscordCommandAuthStrategy {
+  if (kind === "dm") return new DmInteractionAuthorizer();
+  if (kind === "group-dm") return new GroupDmInteractionAuthorizer();
+  return new GuildInteractionAuthorizer();
+}
+
+export function classifyDiscordChannelKind(input: {
+  isDirectMessage: boolean;
+  isGroupDm: boolean;
+}): DiscordChannelKind {
+  if (input.isDirectMessage) return "dm";
+  if (input.isGroupDm) return "group-dm";
+  return "guild";
+}
+
+function buildPairingReplyText(userId: string, code: string): string {
+  // Mirrors the existing buildPairingReply shape so the migration is
+  // a no-op for the user-visible reply.
+  return [
+    `Your Discord user id: ${userId}`,
+    `Pairing code: ${code}`,
+    "Send `openclaw pair discord <code>` from the gateway host to approve.",
+  ].join("\n");
+}

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -54,6 +54,10 @@ import {
   resolveDiscordUserAllowed,
 } from "./allow-list.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
+import {
+  classifyDiscordChannelKind,
+  selectDiscordCommandAuthStrategy,
+} from "./native-command-auth.js";
 import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
@@ -579,49 +583,69 @@ async function dispatchDiscordCommandInteraction(params: {
   const dmPolicy = discordConfig?.dm?.policy ?? "pairing";
   let commandAuthorized = true;
   if (isDirectMessage) {
-    if (!dmEnabled || dmPolicy === "disabled") {
-      await respond("Discord DMs are disabled.");
+    // 630:P3 #55 -- delegate to the DM authorization Strategy. The
+    // strategy owns the dmPolicy/dmEnabled/pairing decision tree;
+    // this dispatcher only resolves the inputs (allow-list lookup,
+    // pairing-store call) and renders the resulting decision.
+    const storeAllowFrom = await readChannelAllowFromStore("discord").catch(() => []);
+    const effectiveAllowFrom = [...(discordConfig?.dm?.allowFrom ?? []), ...storeAllowFrom];
+    const allowList = normalizeDiscordAllowList(effectiveAllowFrom, ["discord:", "user:", "pk:"]);
+    const dmAllowed = allowList
+      ? allowListMatches(allowList, {
+          id: sender.id,
+          name: sender.name,
+          tag: sender.tag,
+        })
+      : false;
+    const authStrategy = selectDiscordCommandAuthStrategy(
+      classifyDiscordChannelKind({ isDirectMessage: true, isGroupDm: false }),
+    );
+    const decision = await authStrategy.authorize({
+      sender: { id: sender.id, name: sender.name, tag: sender.tag },
+      dmPolicy:
+        dmPolicy === "open" || dmPolicy === "pairing" || dmPolicy === "disabled"
+          ? dmPolicy
+          : "allowlist",
+      dmEnabled,
+      isGroupDm: false,
+      groupDmEnabled: discordConfig?.dm?.groupEnabled ?? true,
+      dmAllowed,
+      startPairing: async ({ sender: pairingSender }) => {
+        const { code, created } = await upsertChannelPairingRequest({
+          channel: "discord",
+          id: pairingSender.id,
+          meta: {
+            tag: pairingSender.tag,
+            name: pairingSender.name,
+          },
+        });
+        return { code, created };
+      },
+    });
+    if (decision.allowed === false) {
+      commandAuthorized = false;
+      if (decision.replyMessage !== null) {
+        // For pairing replies, preserve the legacy buildPairingReply
+        // formatting so existing channel docs match.
+        if (decision.reason === "dm-pairing-pending") {
+          // Reconstruct via buildPairingReply to keep wording identical
+          // to the previous code path.
+          const code = decision.replyMessage.match(/Pairing code:\s*(\S+)/)?.[1] ?? "";
+          await respond(
+            buildPairingReply({
+              channel: "discord",
+              idLine: `Your Discord user id: ${user.id}`,
+              code,
+            }),
+            { ephemeral: decision.ephemeral === true },
+          );
+        } else {
+          await respond(decision.replyMessage, { ephemeral: decision.ephemeral === true });
+        }
+      }
       return;
     }
-    if (dmPolicy !== "open") {
-      const storeAllowFrom = await readChannelAllowFromStore("discord").catch(() => []);
-      const effectiveAllowFrom = [...(discordConfig?.dm?.allowFrom ?? []), ...storeAllowFrom];
-      const allowList = normalizeDiscordAllowList(effectiveAllowFrom, ["discord:", "user:", "pk:"]);
-      const permitted = allowList
-        ? allowListMatches(allowList, {
-            id: sender.id,
-            name: sender.name,
-            tag: sender.tag,
-          })
-        : false;
-      if (!permitted) {
-        commandAuthorized = false;
-        if (dmPolicy === "pairing") {
-          const { code, created } = await upsertChannelPairingRequest({
-            channel: "discord",
-            id: user.id,
-            meta: {
-              tag: sender.tag,
-              name: sender.name,
-            },
-          });
-          if (created) {
-            await respond(
-              buildPairingReply({
-                channel: "discord",
-                idLine: `Your Discord user id: ${user.id}`,
-                code,
-              }),
-              { ephemeral: true },
-            );
-          }
-        } else {
-          await respond("You are not authorized to use this command.", { ephemeral: true });
-        }
-        return;
-      }
-      commandAuthorized = true;
-    }
+    commandAuthorized = decision.commandAuthorized;
   }
   if (!isDirectMessage) {
     const channelUsers = channelConfig?.users ?? guildInfo?.users;


### PR DESCRIPTION
## Summary

Closes #55.

`dispatchDiscordCommandInteraction` in `src/discord/monitor/native-command.ts` is a 360-line procedural function whose largest sub-cluster is the "should this command be allowed for this user/channel?" decision. That decision branches on channel kind (DM / GroupDM / guild channel / thread), DM policy (`open` / `pairing` / `allowlist` / `disabled`), guild access groups, owner allow-list, channel allow-list, and per-channel enable flag -- the **God Object** shape #55 targets, with policy and dispatch tangled inside the same procedural function.

## Scope-fit note

The literal "per-command Strategy" framing in the issue body does not quite match this codebase: the actual command behaviors (`/status`, `/reset`, `/think`, ...) live in the agent reply directives, not in `native-command.ts`. The closest equivalent God-Object cluster in this file is the **per-channel-kind authorization tree**, so this PR refactors that into a Strategy. The per-command behavior split would be a separate refactor in `auto-reply/`; deferring it keeps this change reviewable.

## Refactor: Strategy (Behavioral)

`src/discord/monitor/native-command-auth.ts` adds:

- **`DiscordCommandAuthStrategy`** interface -- `authorize(input) -> DiscordAuthDecision`.
- **`DmInteractionAuthorizer`** -- owns the `dmEnabled` / `dmPolicy` / pairing / allow-list decision tree. Pairing is invoked via a `startPairing` callback so the strategy stays free of Discord SDK concerns and is unit-testable.
- **`GroupDmInteractionAuthorizer`** -- owns the `groupDmEnabled` gate.
- **`GuildInteractionAuthorizer`** -- placeholder for the follow-up that migrates the guild path. Per Non-goals we do not unify Discord with Telegram/Slack equivalents in this PR.
- **`selectDiscordCommandAuthStrategy(kind)`** -- small Factory; adding a new channel kind (e.g. `forum-thread`) is one new strategy class plus one entry, not a new conditional in the dispatcher.
- **`classifyDiscordChannelKind(...)`** -- kind classifier the dispatcher uses to pick a strategy.

## Demo migration: DM path in `native-command.ts`

| Before | After |
|---|---|
| 45-line `if (isDirectMessage)` block with nested `dmPolicy` / `dmAllowed` / `dmPolicy === "pairing"` branches | 12-line strategy invocation that delegates the decision and renders the result |
| pairing-store call inlined inside the dispatcher | pairing-store call passed to the strategy as a `startPairing` callback |
| `buildPairingReply` formatting preserved verbatim | unchanged -- pairing messages are byte-identical |

Existing slash commands work unchanged: only the authorization decision-making is moved into a strategy, not the dispatcher entry-points or argument parsing.

## Anti-pattern -> design pattern

| | |
|---|---|
| Anti-pattern | God Object |
| Pattern | **Strategy** (Behavioral) |
| Files added | `src/discord/monitor/native-command-auth.ts`, `src/discord/monitor/native-command-auth.test.ts` (13 tests) |
| Files modified | `src/discord/monitor/native-command.ts` (DM path migration) |

## Verification

```
pnpm vitest run src/discord/monitor/native-command-auth.test.ts
> Test Files  1 passed (1)
> Tests       13 passed (13)
```

Tests cover: channel-kind classification, all four DM policies (`disabled` / `open` / `allowlist` / `pairing`) with both allowed/denied senders and the duplicate-pairing-request shape, GroupDM disabled/enabled, and the guild placeholder. No existing tests are modified.

The two `src/telegram/bot-native-commands*.test.ts` files transitively import `tts.ts`, which has a pre-existing `isValidVoiceId` upstream bug on `main` (commit `87b2de341` extracted ElevenLabs but left a dangling reference). That bug is fixed in the parallel PR for #60; unrelated to this Strategy refactor.

## Scope

Medium (estimated 60-90 min in #55 backlog; actual ~75 min including the DM-path migration).