### PR TITLE
630:P3 #54 -- introduce ChannelPolicyMediator (Mediator) for cross-channel DM policy

### DIFF
--- a/src/channels/policy-mediator.test.ts
+++ b/src/channels/policy-mediator.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChannelPolicyMediator } from "./policy-mediator.js";
+
+describe("ChannelPolicyMediator.shouldProcess", () => {
+  const baseCtx = {
+    channel: "telegram" as const,
+    scope: "dm" as const,
+    senderId: "u1",
+    senderName: "Alice",
+    policy: { enabled: true, policy: "open" as const },
+  };
+
+  it("rejects when channel is disabled", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({ ...baseCtx, policy: { enabled: false } });
+    expect(decision).toEqual({ allowed: false, reason: "channel-disabled" });
+  });
+
+  it("rejects when scope policy is disabled", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      policy: { enabled: true, policy: "disabled" },
+    });
+    expect(decision).toEqual({ allowed: false, reason: "scope-disabled" });
+  });
+
+  it("allows DMs under an open policy", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess(baseCtx);
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("rejects DMs not on the allowlist when policy is allowlist", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      policy: { enabled: true, policy: "allowlist", allowFrom: ["bob"] },
+      allowlistMatch: { allowed: false },
+    });
+    expect(decision).toEqual({
+      allowed: false,
+      reason: "not-on-allowlist",
+      matchedAllowlist: { allowed: false },
+    });
+  });
+
+  it("allows DMs on the allowlist when policy is allowlist", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      policy: { enabled: true, policy: "allowlist", allowFrom: ["alice"] },
+      allowlistMatch: { allowed: true, matchKey: "alice", matchSource: "username" },
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("returns needs-pairing when pairing policy and not yet paired", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      policy: { enabled: true, policy: "pairing" },
+      isPaired: false,
+      allowlistMatch: { allowed: false },
+    });
+    expect(decision.allowed).toBe(false);
+    expect(decision).toMatchObject({ reason: "needs-pairing" });
+  });
+
+  it("allows under pairing policy when already paired", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      policy: { enabled: true, policy: "pairing" },
+      isPaired: true,
+      allowlistMatch: { allowed: false },
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("requires mention in group scope when requireMention is set", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      scope: "group",
+      policy: { enabled: true, requireMention: true },
+      hasMention: false,
+    });
+    expect(decision).toEqual({ allowed: false, reason: "needs-mention" });
+  });
+
+  it("allows group when requireMention is set and mention is present", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      scope: "group",
+      policy: { enabled: true, requireMention: true },
+      hasMention: true,
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  it("allows guild scope without requireMention", () => {
+    const mediator = createChannelPolicyMediator();
+    const decision = mediator.shouldProcess({
+      ...baseCtx,
+      scope: "guild",
+      policy: { enabled: true },
+    });
+    expect(decision.allowed).toBe(true);
+  });
+});
+
+describe("ChannelPolicyMediator.sendTyping", () => {
+  it("returns dispatched=false when no dispatcher registered", async () => {
+    const mediator = createChannelPolicyMediator();
+    const result = await mediator.sendTyping({ channel: "telegram", conversationId: "c1" });
+    expect(result).toEqual({ dispatched: false });
+  });
+
+  it("invokes the registered dispatcher and returns dispatched=true", async () => {
+    const mediator = createChannelPolicyMediator();
+    const dispatcher = vi.fn().mockResolvedValue(undefined);
+    mediator.registerTypingDispatcher("telegram", dispatcher);
+    const result = await mediator.sendTyping({ channel: "telegram", conversationId: "c1" });
+    expect(result).toEqual({ dispatched: true });
+    expect(dispatcher).toHaveBeenCalledWith({ channel: "telegram", conversationId: "c1" });
+  });
+
+  it("does not cross-fire dispatchers across channels", async () => {
+    const mediator = createChannelPolicyMediator();
+    const tg = vi.fn().mockResolvedValue(undefined);
+    mediator.registerTypingDispatcher("telegram", tg);
+    expect(mediator.hasTypingDispatcher("telegram")).toBe(true);
+    expect(mediator.hasTypingDispatcher("discord")).toBe(false);
+    await mediator.sendTyping({ channel: "discord", conversationId: "c1" });
+    expect(tg).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/policy-mediator.ts
+++ b/src/channels/policy-mediator.ts
@@ -1,0 +1,132 @@
+import type { AllowlistMatch } from "./allowlist-match.js";
+
+/**
+ * Channels currently understood by the policy mediator. Channel adapters
+ * register themselves here so the mediator can apply consistent policy and
+ * typing-indicator logic across all of them. New channels just add a string
+ * here without changing call sites in adapters.
+ */
+export type SupportedChannelKind =
+  | "telegram"
+  | "discord"
+  | "whatsapp"
+  | "slack"
+  | "signal"
+  | "imessage"
+  | "bluebubbles"
+  | "msteams"
+  | "matrix"
+  | "zalo";
+
+export type InboundScope = "dm" | "group" | "guild" | "channel";
+
+/**
+ * Policy declared per channel + scope (mirrors the per-channel config blocks
+ * already in OpenClawConfig: dm.policy, dm.allowFrom, group.requireMention).
+ * Centralizing the shape here means a config change only touches one place.
+ */
+export type ChannelPolicy = {
+  enabled: boolean;
+  policy?: "open" | "allowlist" | "pairing" | "disabled";
+  allowFrom?: string[];
+  requireMention?: boolean;
+};
+
+export type InboundDecisionReason =
+  | "channel-disabled"
+  | "scope-disabled"
+  | "not-on-allowlist"
+  | "needs-pairing"
+  | "needs-mention";
+
+export type InboundDecision =
+  | { allowed: true; matchedAllowlist?: AllowlistMatch }
+  | { allowed: false; reason: InboundDecisionReason; matchedAllowlist?: AllowlistMatch };
+
+export type InboundContext = {
+  channel: SupportedChannelKind;
+  scope: InboundScope;
+  senderId: string;
+  senderName?: string;
+  policy: ChannelPolicy;
+  isPaired?: boolean;
+  hasMention?: boolean;
+  /**
+   * Pluggable allowlist matcher so channel-specific match rules
+   * (Telegram tg: prefixes, Discord allow-groups) stay in their adapters
+   * and the mediator just consumes the boolean result + match metadata.
+   */
+  allowlistMatch?: AllowlistMatch;
+};
+
+export type TypingTarget = {
+  channel: SupportedChannelKind;
+  conversationId: string;
+};
+
+export type TypingDispatcher = (target: TypingTarget) => Promise<void>;
+
+export type ChannelPolicyMediator = {
+  shouldProcess(ctx: InboundContext): InboundDecision;
+  sendTyping(target: TypingTarget): Promise<{ dispatched: boolean }>;
+  registerTypingDispatcher(channel: SupportedChannelKind, fn: TypingDispatcher): void;
+  hasTypingDispatcher(channel: SupportedChannelKind): boolean;
+};
+
+export function createChannelPolicyMediator(): ChannelPolicyMediator {
+  const typingDispatchers = new Map<SupportedChannelKind, TypingDispatcher>();
+
+  return {
+    shouldProcess(ctx) {
+      if (!ctx.policy.enabled) {
+        return { allowed: false, reason: "channel-disabled" };
+      }
+
+      if (ctx.policy.policy === "disabled") {
+        return { allowed: false, reason: "scope-disabled" };
+      }
+
+      if (ctx.scope === "group" || ctx.scope === "guild" || ctx.scope === "channel") {
+        if (ctx.policy.requireMention && !ctx.hasMention) {
+          return { allowed: false, reason: "needs-mention" };
+        }
+        return { allowed: true, matchedAllowlist: ctx.allowlistMatch };
+      }
+
+      if (ctx.policy.policy === "open") {
+        return { allowed: true, matchedAllowlist: ctx.allowlistMatch };
+      }
+
+      const matched = ctx.allowlistMatch?.allowed === true;
+      if (matched) {
+        return { allowed: true, matchedAllowlist: ctx.allowlistMatch };
+      }
+
+      if (ctx.policy.policy === "pairing") {
+        if (ctx.isPaired) {
+          return { allowed: true, matchedAllowlist: ctx.allowlistMatch };
+        }
+        return { allowed: false, reason: "needs-pairing", matchedAllowlist: ctx.allowlistMatch };
+      }
+
+      return { allowed: false, reason: "not-on-allowlist", matchedAllowlist: ctx.allowlistMatch };
+    },
+
+    async sendTyping(target) {
+      const fn = typingDispatchers.get(target.channel);
+      if (!fn) {
+        return { dispatched: false };
+      }
+      await fn(target);
+      return { dispatched: true };
+    },
+
+    registerTypingDispatcher(channel, fn) {
+      typingDispatchers.set(channel, fn);
+    },
+
+    hasTypingDispatcher(channel) {
+      return typingDispatchers.has(channel);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Closes #54.

This PR introduces `ChannelPolicyMediator` -- a central object that owns DM-policy resolution, allowlist gating, scope/mention rules, and typing-indicator dispatch across all channel adapters. Per the issue Non-goals ("limit scope to allowFrom/policy + typing indicators -- do not attempt to unify all channel logic"), this PR lands the **infrastructure only**; live channel adapters keep their existing call paths and are migrated in follow-ups.

## Anti-pattern -> design pattern

| | |
|---|---|
| Anti-pattern | Shotgun Surgery |
| Pattern | **Mediator** (Behavioral) |
| Files added | `src/channels/policy-mediator.ts`, `src/channels/policy-mediator.test.ts` |
| Files migrated | none yet (per Non-goals) |
| LOC delta | +271 / -0 |

## Why Mediator (not Facade or Strategy)

The duplicated logic across 9 channel adapters is *not* a complexity-hiding problem (Facade) or a per-channel behavior-selection problem (Strategy). Each adapter independently re-implements the *same* rules: scope check -> enabled check -> policy === "disabled" -> requireMention -> allowlist -> pairing. The natural fix is a single object that owns those rules and exposes a tiny shared surface to each channel: `mediator.shouldProcess(ctx) -> InboundDecision` and `mediator.sendTyping(target)`. That is the Mediator role: components stop talking to each other (or, here, stop redundantly re-implementing the same talking) and instead talk through a central object.

## What landed

1. `SupportedChannelKind` -- typed enum of the 10 channel kinds the mediator currently understands; new channels add a string here, not a re-implementation.
2. `ChannelPolicy` -- the per-channel + per-scope policy shape (mirrors the existing `dm.policy`/`dm.allowFrom`/`group.requireMention` config blocks already in `OpenClawConfig`, gathered in one place).
3. `InboundContext` -- the per-message input the adapter passes to the mediator (channel, scope, sender, policy, isPaired, hasMention, allowlistMatch).
4. `InboundDecision` -- a tagged result (`{ allowed: true, matchedAllowlist? }` or `{ allowed: false, reason: ..., matchedAllowlist? }`) so the adapter renders the right denial reply without re-deriving it.
5. `createChannelPolicyMediator()` -- factory returning the shared mediator instance with a registry-backed typing dispatcher map.

The allowlist-matching rule itself stays in each adapter (Telegram `tg:` prefixes, Discord allow-groups, Slack username forms) -- those are channel-specific lookups and don't belong in the mediator. The adapter just hands the mediator the boolean result + match metadata via `allowlistMatch`.

## Verification

```
pnpm vitest run src/channels/policy-mediator.test.ts
> Test Files  1 passed (1)
> Tests       13 passed (13)
```

The 13 tests cover all decision branches:
- `channel-disabled` and `scope-disabled` rejections
- `open` policy in DM scope (allowed)
- `allowlist` policy with both allowed and denied senders
- `pairing` policy with both `isPaired=true` (allowed) and `isPaired=false` (`needs-pairing`)
- `requireMention` in `group` scope, with and without mention
- `guild` scope without `requireMention`
- `sendTyping` with no dispatcher registered (`dispatched=false`), with dispatcher (`dispatched=true`), and across-channel isolation (Telegram dispatcher does not fire for a Discord target).

## Non-goals (carried over from the issue)

- Do not rearchitect message parsing or rendering per channel.
- Do not migrate live channel adapters in this PR (follow-up PRs migrate Telegram and Discord first; the mediator's surface is intentionally small enough that a one-line call replaces the existing duplicated block).
- No protocol changes.

## Scope

Medium (estimated 60-90 min in #54 backlog; actual ~75 min). One new file + one new test file, no edits to existing modules. Adopting the mediator inside `src/telegram/bot.ts` and `src/discord/monitor.ts` is the next reviewable PR.
