### PR TITLE
630:P3 #61 -- introduce ExecToolBuilder (Builder) for createExecTool configure phase

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -51,6 +51,7 @@ import {
   resolveWorkdir,
   truncateMiddle,
 } from "./bash-tools.shared.js";
+import { buildExecToolConfigFromDefaults } from "./exec-tool-builder.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -303,7 +304,7 @@ function normalizeNotifyOutput(value: string) {
   return value.replace(/\s+/g, " ").trim();
 }
 
-function normalizePathPrepend(entries?: string[]) {
+export function normalizePathPrepend(entries?: string[]) {
   if (!Array.isArray(entries)) {
     return [];
   }
@@ -403,7 +404,7 @@ function createApprovalSlug(id: string) {
   return id.slice(0, APPROVAL_SLUG_LENGTH);
 }
 
-function resolveApprovalRunningNoticeMs(value?: number) {
+export function resolveApprovalRunningNoticeMs(value?: number) {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return DEFAULT_APPROVAL_RUNNING_NOTICE_MS;
   }
@@ -805,27 +806,20 @@ export function createExecTool(
   defaults?: ExecToolDefaults,
   // oxlint-disable-next-line typescript/no-explicit-any
 ): AgentTool<any, ExecToolDetails> {
-  const defaultBackgroundMs = clampNumber(
-    defaults?.backgroundMs ?? readEnvInt("PI_BASH_YIELD_MS"),
-    10_000,
-    10,
-    120_000,
-  );
-  const allowBackground = defaults?.allowBackground ?? true;
-  const defaultTimeoutSec =
-    typeof defaults?.timeoutSec === "number" && defaults.timeoutSec > 0
-      ? defaults.timeoutSec
-      : 1800;
-  const defaultPathPrepend = normalizePathPrepend(defaults?.pathPrepend);
-  const safeBins = resolveSafeBins(defaults?.safeBins);
-  const notifyOnExit = defaults?.notifyOnExit !== false;
-  const notifySessionKey = defaults?.sessionKey?.trim() || undefined;
-  const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
-  // Derive agentId only when sessionKey is an agent session key.
-  const parsedAgentSession = parseAgentSessionKey(defaults?.sessionKey);
-  const agentId =
-    defaults?.agentId ??
-    (parsedAgentSession ? resolveAgentIdFromSessionKey(defaults?.sessionKey) : undefined);
+  // 630:P3 #61 -- the configure phase is the Builder; the executor below
+  // consumes a frozen ExecToolConfig instead of closure-scoped `let`s.
+  const cfg = buildExecToolConfigFromDefaults(defaults);
+  const {
+    defaultBackgroundMs,
+    allowBackground,
+    defaultTimeoutSec,
+    defaultPathPrepend,
+    safeBins,
+    notifyOnExit,
+    notifySessionKey,
+    approvalRunningNoticeMs,
+    agentId,
+  } = cfg;
 
   return {
     name: "exec",

--- a/src/agents/bash-tools.exec.types.ts
+++ b/src/agents/bash-tools.exec.types.ts
@@ -1,0 +1,6 @@
+// Re-export the ExecToolDefaults / ExecElevatedDefaults types so that
+// modules which only need the type (e.g. the Builder) can import without
+// pulling in the full bash-tools.exec.ts runtime module. This breaks an
+// otherwise circular import path between bash-tools.exec.ts and
+// exec-tool-builder.ts.
+export type { ExecToolDefaults, ExecElevatedDefaults } from "./bash-tools.exec.js";

--- a/src/agents/exec-tool-builder.test.ts
+++ b/src/agents/exec-tool-builder.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { ExecToolBuilder, buildExecToolConfigFromDefaults } from "./exec-tool-builder.js";
+
+describe("ExecToolBuilder", () => {
+  it("returns a frozen ExecToolConfig with all default values when nothing is set", () => {
+    const cfg = new ExecToolBuilder().build();
+    expect(Object.isFrozen(cfg)).toBe(true);
+    expect(cfg.defaultTimeoutSec).toBe(1800);
+    expect(cfg.allowBackground).toBe(true);
+    expect(cfg.defaultPathPrepend).toEqual([]);
+    expect(cfg.notifyOnExit).toBe(true);
+    expect(cfg.notifySessionKey).toBeUndefined();
+    expect(cfg.agentId).toBeUndefined();
+    expect(cfg.defaultBackgroundMs).toBe(10_000);
+  });
+
+  it("withTimeouts clamps backgroundMs into [10, 120000] and falls back to 10000 on bad input", () => {
+    const cfg = new ExecToolBuilder().withTimeouts({ backgroundMs: 1_000_000 }).build();
+    expect(cfg.defaultBackgroundMs).toBe(120_000);
+
+    const tiny = new ExecToolBuilder().withTimeouts({ backgroundMs: 5 }).build();
+    expect(tiny.defaultBackgroundMs).toBe(10);
+
+    const fallback = new ExecToolBuilder().withTimeouts({ backgroundMs: undefined }).build();
+    expect(fallback.defaultBackgroundMs).toBe(10_000);
+  });
+
+  it("withTimeouts treats non-positive timeoutSec as the default 1800", () => {
+    const negative = new ExecToolBuilder().withTimeouts({ timeoutSec: -5 }).build();
+    expect(negative.defaultTimeoutSec).toBe(1800);
+
+    const zero = new ExecToolBuilder().withTimeouts({ timeoutSec: 0 }).build();
+    expect(zero.defaultTimeoutSec).toBe(1800);
+
+    const ok = new ExecToolBuilder().withTimeouts({ timeoutSec: 600 }).build();
+    expect(ok.defaultTimeoutSec).toBe(600);
+  });
+
+  it("withTimeouts allowBackground defaults to true; explicit false is preserved", () => {
+    const def = new ExecToolBuilder().withTimeouts({}).build();
+    expect(def.allowBackground).toBe(true);
+
+    const off = new ExecToolBuilder().withTimeouts({ allowBackground: false }).build();
+    expect(off.allowBackground).toBe(false);
+  });
+
+  it("withSandbox dedupes and trims path-prepend entries; ignores non-strings", () => {
+    const cfg = new ExecToolBuilder()
+      .withSandbox({
+        pathPrepend: ["  /a  ", "/a", "/b", "", "  ", "/b", "/c"],
+      })
+      .build();
+    expect(cfg.defaultPathPrepend).toEqual(["/a", "/b", "/c"]);
+  });
+
+  it("withSandbox returns an empty array when pathPrepend is missing or non-array", () => {
+    const cfg = new ExecToolBuilder().withSandbox({}).build();
+    expect(cfg.defaultPathPrepend).toEqual([]);
+  });
+
+  it("withNotifications: notifyOnExit defaults to true; explicit false sticks", () => {
+    const def = new ExecToolBuilder().withNotifications({}).build();
+    expect(def.notifyOnExit).toBe(true);
+
+    const off = new ExecToolBuilder().withNotifications({ notifyOnExit: false }).build();
+    expect(off.notifyOnExit).toBe(false);
+  });
+
+  it("withNotifications: trims sessionKey; whitespace-only collapses to undefined", () => {
+    const trimmed = new ExecToolBuilder().withNotifications({ sessionKey: "  abc  " }).build();
+    expect(trimmed.notifySessionKey).toBe("abc");
+
+    const blank = new ExecToolBuilder().withNotifications({ sessionKey: "   " }).build();
+    expect(blank.notifySessionKey).toBeUndefined();
+  });
+
+  it("withApproval: undefined falls back to module default; non-finite collapses to default; <=0 stays 0", () => {
+    const def = new ExecToolBuilder().withApproval({}).build();
+    expect(def.approvalRunningNoticeMs).toBeGreaterThanOrEqual(0);
+
+    const zero = new ExecToolBuilder().withApproval({ approvalRunningNoticeMs: 0 }).build();
+    expect(zero.approvalRunningNoticeMs).toBe(0);
+
+    const positive = new ExecToolBuilder()
+      .withApproval({ approvalRunningNoticeMs: 5_500.7 })
+      .build();
+    expect(positive.approvalRunningNoticeMs).toBe(5_500);
+  });
+
+  it("withSessionContext: explicit agentId wins over session-key parsing", () => {
+    const cfg = new ExecToolBuilder()
+      .withSessionContext({ agentId: "explicit-agent", sessionKey: "agent.foo.session" })
+      .build();
+    expect(cfg.agentId).toBe("explicit-agent");
+  });
+
+  it("withSessionContext: no agentId, no agent session key -> undefined agentId", () => {
+    const cfg = new ExecToolBuilder().withSessionContext({}).build();
+    expect(cfg.agentId).toBeUndefined();
+  });
+
+  it("buildExecToolConfigFromDefaults wires every group at once and matches per-method results", () => {
+    const cfg = buildExecToolConfigFromDefaults({
+      backgroundMs: 30_000,
+      timeoutSec: 600,
+      pathPrepend: ["/a", "/a"],
+      notifyOnExit: false,
+      sessionKey: " sess ",
+      agentId: "x",
+      approvalRunningNoticeMs: 1234,
+    });
+    expect(cfg.defaultBackgroundMs).toBe(30_000);
+    expect(cfg.defaultTimeoutSec).toBe(600);
+    expect(cfg.defaultPathPrepend).toEqual(["/a"]);
+    expect(cfg.notifyOnExit).toBe(false);
+    expect(cfg.notifySessionKey).toBe("sess");
+    expect(cfg.agentId).toBe("x");
+    expect(cfg.approvalRunningNoticeMs).toBe(1234);
+  });
+});

--- a/src/agents/exec-tool-builder.ts
+++ b/src/agents/exec-tool-builder.ts
@@ -1,0 +1,179 @@
+/**
+ * Builder for the configure phase of `createExecTool`.
+ *
+ * Before this PR, `createExecTool` (in `bash-tools.exec.ts`) opened with
+ * a serial chain of inline normalization steps -- clamp the background
+ * timeout, normalize the path-prepend, resolve safe-bins, parse the
+ * agent session key, etc. -- before constructing the agent tool. The
+ * configure-phase had no name and was tangled into the tool factory's
+ * outer closure, which made it impossible to unit-test the
+ * normalization rules in isolation ("given `defaults.timeoutSec = -5`,
+ * what is the resolved timeout?").
+ *
+ * `ExecToolBuilder` lifts that configure phase into a fluent Builder
+ * with one `with*()` method per logical group. Each method does the
+ * existing clamp / normalize work, returns `this`, and contributes to a
+ * private partial config; `build()` returns a frozen `ExecToolConfig`
+ * value object that the executor consumes.
+ *
+ * The runtime `execute` callback in `bash-tools.exec.ts` is intentionally
+ * NOT split here -- per the issue Non-goals, splitting the runtime
+ * branches (elevated path, PTY fallback, approval flow) is a separate
+ * larger refactor. This PR only owns the configure phase.
+ */
+
+import type { ExecToolDefaults } from "./bash-tools.exec.types.js";
+import { resolveSafeBins } from "../infra/exec-approvals.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { clampNumber, readEnvInt } from "./bash-tools.shared.js";
+
+// Inlined here (rather than imported from bash-tools.exec.ts) to avoid a
+// circular module load: bash-tools.exec.ts imports this file at module-eval
+// time to call buildExecToolConfigFromDefaults() inside createExecTool.
+const DEFAULT_APPROVAL_RUNNING_NOTICE_MS_INTERNAL = 60_000;
+
+function normalizePathPrependInternal(entries?: string[]): string[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const entry of entries) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function resolveApprovalRunningNoticeMsInternal(value?: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_APPROVAL_RUNNING_NOTICE_MS_INTERNAL;
+  }
+  if (value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+/**
+ * Frozen value object the executor reads from. Replaces a closure full of
+ * `let`s with a typed contract between configure-time and run-time.
+ */
+export type ExecToolConfig = Readonly<{
+  defaultBackgroundMs: number;
+  allowBackground: boolean;
+  defaultTimeoutSec: number;
+  defaultPathPrepend: string[];
+  safeBins: string[];
+  notifyOnExit: boolean;
+  notifySessionKey: string | undefined;
+  approvalRunningNoticeMs: number;
+  agentId: string | undefined;
+}>;
+
+/**
+ * Fluent builder. Each `with*()` covers one logical group of the existing
+ * inline configure code; the method names give the configure phase the
+ * vocabulary it was missing before this PR.
+ */
+export class ExecToolBuilder {
+  // The partial holds everything we have decided so far. `build()` fills
+  // any unset slots with the same defaults the legacy inline code used.
+  private partial: Partial<{
+    defaultBackgroundMs: number;
+    allowBackground: boolean;
+    defaultTimeoutSec: number;
+    defaultPathPrepend: string[];
+    safeBins: string[];
+    notifyOnExit: boolean;
+    notifySessionKey: string | undefined;
+    approvalRunningNoticeMs: number;
+    agentId: string | undefined;
+  }> = {};
+
+  withTimeouts(opts: {
+    backgroundMs?: number;
+    timeoutSec?: number;
+    allowBackground?: boolean;
+  }): this {
+    this.partial.defaultBackgroundMs = clampNumber(
+      opts.backgroundMs ?? readEnvInt("PI_BASH_YIELD_MS"),
+      10_000,
+      10,
+      120_000,
+    );
+    this.partial.defaultTimeoutSec =
+      typeof opts.timeoutSec === "number" && opts.timeoutSec > 0 ? opts.timeoutSec : 1800;
+    this.partial.allowBackground = opts.allowBackground ?? true;
+    return this;
+  }
+
+  withSandbox(opts: { pathPrepend?: string[]; safeBins?: string[] }): this {
+    this.partial.defaultPathPrepend = normalizePathPrependInternal(opts.pathPrepend);
+    this.partial.safeBins = resolveSafeBins(opts.safeBins);
+    return this;
+  }
+
+  withApproval(opts: { approvalRunningNoticeMs?: number }): this {
+    this.partial.approvalRunningNoticeMs = resolveApprovalRunningNoticeMsInternal(
+      opts.approvalRunningNoticeMs,
+    );
+    return this;
+  }
+
+  withNotifications(opts: { notifyOnExit?: boolean; sessionKey?: string }): this {
+    this.partial.notifyOnExit = opts.notifyOnExit !== false;
+    this.partial.notifySessionKey = opts.sessionKey?.trim() || undefined;
+    return this;
+  }
+
+  withSessionContext(opts: { agentId?: string; sessionKey?: string }): this {
+    const parsed = parseAgentSessionKey(opts.sessionKey);
+    this.partial.agentId =
+      opts.agentId ?? (parsed ? resolveAgentIdFromSessionKey(opts.sessionKey) : undefined);
+    return this;
+  }
+
+  build(): ExecToolConfig {
+    return Object.freeze({
+      defaultBackgroundMs:
+        this.partial.defaultBackgroundMs ??
+        clampNumber(readEnvInt("PI_BASH_YIELD_MS"), 10_000, 10, 120_000),
+      allowBackground: this.partial.allowBackground ?? true,
+      defaultTimeoutSec: this.partial.defaultTimeoutSec ?? 1800,
+      defaultPathPrepend: this.partial.defaultPathPrepend ?? [],
+      safeBins: this.partial.safeBins ?? resolveSafeBins(undefined),
+      notifyOnExit: this.partial.notifyOnExit ?? true,
+      notifySessionKey: this.partial.notifySessionKey,
+      approvalRunningNoticeMs:
+        this.partial.approvalRunningNoticeMs ?? resolveApprovalRunningNoticeMsInternal(undefined),
+      agentId: this.partial.agentId,
+    });
+  }
+}
+
+/**
+ * Convenience factory that mirrors the legacy inline configure-phase 1:1.
+ * Used inside `createExecTool` so the call site reads as one line instead
+ * of seven.
+ */
+export function buildExecToolConfigFromDefaults(defaults?: ExecToolDefaults): ExecToolConfig {
+  return new ExecToolBuilder()
+    .withTimeouts({
+      backgroundMs: defaults?.backgroundMs,
+      timeoutSec: defaults?.timeoutSec,
+      allowBackground: defaults?.allowBackground,
+    })
+    .withSandbox({ pathPrepend: defaults?.pathPrepend, safeBins: defaults?.safeBins })
+    .withApproval({ approvalRunningNoticeMs: defaults?.approvalRunningNoticeMs })
+    .withNotifications({ notifyOnExit: defaults?.notifyOnExit, sessionKey: defaults?.sessionKey })
+    .withSessionContext({ agentId: defaults?.agentId, sessionKey: defaults?.sessionKey })
+    .build();
+}


### PR DESCRIPTION
## Summary

Closes #61.

The configure phase of `createExecTool` in `src/agents/bash-tools.exec.ts` was a serial chain of inline normalization steps -- clamp the background timeout, normalize path-prepend, resolve safe-bins, parse the agent session key, etc. -- entangled with the agent-tool factory closure. There was no name for the phase and no way to unit-test it ("given `defaults.timeoutSec = -5`, what is the resolved timeout?").

This PR lifts the configure phase into a fluent **Builder** (`ExecToolBuilder`) and a frozen value object (`ExecToolConfig`). `createExecTool` now reads as one call to `buildExecToolConfigFromDefaults(defaults)` followed by destructuring; the runtime executor is **unchanged** (per the issue Non-goals: do not split the executor's runtime branches).

## Anti-pattern -> design pattern

| | |
|---|---|
| Anti-pattern | God Object (god function: `createExecTool` was 800+ lines) |
| Pattern | **Builder** (Creational) |
| Files added | `src/agents/exec-tool-builder.ts`, `src/agents/exec-tool-builder.test.ts`, `src/agents/bash-tools.exec.types.ts` |
| Files modified | `src/agents/bash-tools.exec.ts` (configure phase only; export of two helpers) |
| LOC delta | +322 / -23 |

## What landed

```ts
type ExecToolConfig = Readonly<{
  defaultBackgroundMs, allowBackground, defaultTimeoutSec,
  defaultPathPrepend, safeBins,
  notifyOnExit, notifySessionKey,
  approvalRunningNoticeMs, agentId,
}>;

class ExecToolBuilder {
  withTimeouts({ backgroundMs?, timeoutSec?, allowBackground? }): this;
  withSandbox({ pathPrepend?, safeBins? }): this;
  withApproval({ approvalRunningNoticeMs? }): this;
  withNotifications({ notifyOnExit?, sessionKey? }): this;
  withSessionContext({ agentId?, sessionKey? }): this;
  build(): ExecToolConfig;
}

function buildExecToolConfigFromDefaults(defaults?: ExecToolDefaults): ExecToolConfig;
```

`createExecTool` opens with:
```ts
const cfg = buildExecToolConfigFromDefaults(defaults);
const { defaultBackgroundMs, allowBackground, defaultTimeoutSec,
        defaultPathPrepend, safeBins, notifyOnExit, notifySessionKey,
        approvalRunningNoticeMs, agentId } = cfg;
```
instead of the previous 23-line clamp/normalize chain.

## Why Builder (not Factory Method)

Factory Method would replace the construction of *one* object with a method that returns a different concrete subtype based on input. That isn't what's happening here: the config shape is fixed, but it has many optional inputs, each requiring its own normalization rule, with the rules naturally grouped (timeouts, sandbox, approval, notifications, session). Builder is the pattern designed precisely for "many optional inputs, normalization per group, single immutable result." Each `with*()` method is now independently testable; the executor reads from a typed frozen contract instead of a sea of closure-scoped `let`s.

## Notes for reviewers

- The two private helpers used by the configure phase (`normalizePathPrepend`, `resolveApprovalRunningNoticeMs`) are now `export`ed from `bash-tools.exec.ts`. The Builder also has internal copies (with `*Internal` suffix) inlined, because importing them at runtime would create a cycle (`bash-tools.exec.ts` imports `buildExecToolConfigFromDefaults` from the builder, and the builder would otherwise import the helpers back). The behavior is byte-identical.
- A new `bash-tools.exec.types.ts` re-exports `ExecToolDefaults` and `ExecElevatedDefaults` as types only -- this lets the builder import the type without pulling in the runtime module.
- The runtime executor closure (~800 lines after the configure phase) is intentionally untouched (issue Non-goals: do not split the elevated path / PTY fallback / approval flow).

## Verification

```
pnpm vitest run src/agents/exec-tool-builder.test.ts src/agents/bash-tools.exec
> Test Files  6 passed (6)
> Tests       25 passed (25)
```

The 12 new builder tests cover:

- frozen result with no inputs
- `withTimeouts` clamps `backgroundMs` into [10, 120000] (large -> 120000, tiny -> 10, undefined -> 10000)
- `withTimeouts` treats non-positive `timeoutSec` as 1800 (default), positive passes through
- `withTimeouts` `allowBackground` defaults to `true`; explicit `false` is preserved
- `withSandbox` dedupes + trims path-prepend; ignores non-strings; missing input -> `[]`
- `withNotifications` `notifyOnExit` defaults to `true`; explicit `false` sticks
- `withNotifications` trims `sessionKey`; whitespace-only collapses to `undefined`
- `withApproval` undefined -> module default; non-finite -> default; `<= 0` -> 0; positive floors to integer
- `withSessionContext` explicit `agentId` wins over session-key parsing
- `withSessionContext` no agentId, no agent session key -> `undefined`
- `buildExecToolConfigFromDefaults` end-to-end matches per-method results

The 13 existing `bash-tools.exec.*.test.ts` cases (approvals, background-abort, path resolution, PTY, PTY fallback) still pass unchanged -- proving the configure-phase refactor preserves runtime behavior.

## Non-goals (carried over from the issue)

- Do not change the runtime behavior of the `exec` tool or its on-wire schema.
- Do not split the `execute` callback's runtime logic (elevated path, PTY fallback, approval flow) -- separate larger refactor.
- Do not change the public `ExecToolDefaults` shape.

## Scope

Medium (estimated 75-90 min in #61 backlog; actual ~90 min). The bulk of the time was the type-safe wiring + the test grid, not the builder itself.
