### PR TITLE
630:P3 #63 -- introduce embeddings Abstract Factory registry

### DIFF
--- a/src/memory/embedding-provider-factory.test.ts
+++ b/src/memory/embedding-provider-factory.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AUTO_FALLBACK_ORDER,
+  createEmbeddingProviderRegistry,
+  createLocalEmbeddingFactory,
+  geminiEmbeddingFactory,
+  openAiEmbeddingFactory,
+  voyageEmbeddingFactory,
+} from "./embedding-provider-factory.js";
+
+describe("EmbeddingProviderRegistry (Abstract Factory)", () => {
+  function makeLocalFactory() {
+    return createLocalEmbeddingFactory({
+      createLocalProvider: vi.fn().mockResolvedValue({
+        id: "local",
+        model: "test-local",
+        embedQuery: async () => [0],
+        embedBatch: async () => [[0]],
+      }),
+      formatLocalSetupError: vi.fn().mockReturnValue("local install hint"),
+    });
+  }
+
+  it("registers all four built-in providers exactly once", () => {
+    const registry = createEmbeddingProviderRegistry(makeLocalFactory());
+    expect(registry.size).toBe(4);
+    expect(registry.get("openai")?.id).toBe("openai");
+    expect(registry.get("gemini")?.id).toBe("gemini");
+    expect(registry.get("voyage")?.id).toBe("voyage");
+    expect(registry.get("local")?.id).toBe("local");
+  });
+
+  it("local factory delegates create() to the injected createLocalProvider", async () => {
+    const localFactory = makeLocalFactory();
+    const product = await localFactory.create({});
+    expect(product.provider.id).toBe("local");
+    expect(product.openAi).toBeUndefined();
+    expect(product.gemini).toBeUndefined();
+    expect(product.voyage).toBeUndefined();
+  });
+
+  it("local factory delegates formatSetupError() to the injected formatter", () => {
+    const localFactory = makeLocalFactory();
+    const out = localFactory.formatSetupError(new Error("missing dep"));
+    expect(out).toBe("local install hint");
+  });
+
+  it("non-local factories format setup errors with the default formatter (Error.message)", () => {
+    expect(openAiEmbeddingFactory.formatSetupError(new Error("boom"))).toBe("boom");
+    expect(geminiEmbeddingFactory.formatSetupError(new Error("nope"))).toBe("nope");
+    expect(voyageEmbeddingFactory.formatSetupError(new Error("fail"))).toBe("fail");
+  });
+
+  it("non-local factories stringify non-Error inputs", () => {
+    expect(openAiEmbeddingFactory.formatSetupError("x")).toBe("x");
+    expect(openAiEmbeddingFactory.formatSetupError(123)).toBe("123");
+  });
+
+  it("AUTO_FALLBACK_ORDER excludes local and lists the three remote providers in order", () => {
+    expect(AUTO_FALLBACK_ORDER).toEqual(["openai", "gemini", "voyage"]);
+    // type-level: local cannot appear in this array
+  });
+
+  it("the registry's keys ARE the canonical provider id list (no other source)", () => {
+    const registry = createEmbeddingProviderRegistry(makeLocalFactory());
+    const ids = Array.from(registry.keys()).sort();
+    expect(ids).toEqual(["gemini", "local", "openai", "voyage"]);
+  });
+
+  it("a custom local factory can completely replace the default behavior", async () => {
+    const customLocal = createLocalEmbeddingFactory({
+      createLocalProvider: vi.fn().mockResolvedValue({
+        id: "local",
+        model: "alt-local",
+        embedQuery: async () => [1],
+        embedBatch: async () => [[1]],
+      }),
+      formatLocalSetupError: () => "alt hint",
+    });
+    const registry = createEmbeddingProviderRegistry(customLocal);
+    const product = await registry.get("local")!.create({});
+    expect(product.provider.model).toBe("alt-local");
+    expect(registry.get("local")!.formatSetupError(new Error("x"))).toBe("alt hint");
+  });
+});

--- a/src/memory/embedding-provider-factory.ts
+++ b/src/memory/embedding-provider-factory.ts
@@ -1,0 +1,148 @@
+/**
+ * Abstract Factory for embeddings providers.
+ *
+ * Before this PR, the embeddings provider family lived in five separate
+ * vocabularies inside `embeddings.ts`:
+ *   1. the string union  ("openai" | "local" | "gemini" | "voyage")
+ *   2. the createProvider switch (one branch per id)
+ *   3. the auto-mode fallback array  (["openai","gemini","voyage"])
+ *   4. the result shape (optional fields per provider)
+ *   5. the per-id formatSetupError dispatch
+ *
+ * Adding a new provider was a textbook Shotgun Surgery edit: a new
+ * branch + a new optional field + a new fallback entry + a new error
+ * formatting case. None of it was compiler-enforced.
+ *
+ * This module introduces an `EmbeddingProviderFactory` interface and a
+ * registry of concrete factories. Each factory owns its id, default
+ * model, creation logic, and setup-error formatting in one place. The
+ * `createEmbeddingProvider` switch becomes a registry lookup; the
+ * `auto`-mode order becomes the named constant `AUTO_FALLBACK_ORDER`.
+ */
+
+import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
+import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
+import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
+
+export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage";
+
+/**
+ * The shape any concrete embeddings client returns. The optional client
+ * fields preserve backward compatibility with the legacy
+ * EmbeddingProviderResult shape (used by `manager.ts` to reach into
+ * provider-specific clients without re-discriminating).
+ */
+export type EmbeddingProviderProduct = {
+  provider: {
+    id: string;
+    model: string;
+    embedQuery: (text: string) => Promise<number[]>;
+    embedBatch: (texts: string[]) => Promise<number[][]>;
+  };
+  openAi?: OpenAiEmbeddingClient;
+  gemini?: GeminiEmbeddingClient;
+  voyage?: VoyageEmbeddingClient;
+};
+
+/** A factory for one embeddings-provider family. */
+export type EmbeddingProviderFactory<TOptions = unknown> = {
+  readonly id: EmbeddingProviderId;
+  /** Provider-specific creation. The factory owns the SDK + the result shape. */
+  create(options: TOptions): Promise<EmbeddingProviderProduct>;
+  /** Provider-specific setup-error formatting (Local has a long install hint; others are plain). */
+  formatSetupError(err: unknown): string;
+};
+
+function defaultFormatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+// One factory per provider. Each one owns its branch of the legacy
+// switch + the way its setup errors should be rendered.
+
+export const openAiEmbeddingFactory: EmbeddingProviderFactory<unknown> = {
+  id: "openai",
+  async create(options) {
+    const { provider, client } = await createOpenAiEmbeddingProvider(
+      options as Parameters<typeof createOpenAiEmbeddingProvider>[0],
+    );
+    return { provider, openAi: client };
+  },
+  formatSetupError: defaultFormatError,
+};
+
+export const geminiEmbeddingFactory: EmbeddingProviderFactory<unknown> = {
+  id: "gemini",
+  async create(options) {
+    const { provider, client } = await createGeminiEmbeddingProvider(
+      options as Parameters<typeof createGeminiEmbeddingProvider>[0],
+    );
+    return { provider, gemini: client };
+  },
+  formatSetupError: defaultFormatError,
+};
+
+export const voyageEmbeddingFactory: EmbeddingProviderFactory<unknown> = {
+  id: "voyage",
+  async create(options) {
+    const { provider, client } = await createVoyageEmbeddingProvider(
+      options as Parameters<typeof createVoyageEmbeddingProvider>[0],
+    );
+    return { provider, voyage: client };
+  },
+  formatSetupError: defaultFormatError,
+};
+
+/**
+ * Local factory. The actual creation logic + the verbose setup-error
+ * formatting live in `embeddings.ts` (because they pull in node-llama-cpp
+ * lazily and have a long install hint message). The factory accepts both
+ * dependencies as injection so this module stays node-llama-cpp-free.
+ */
+export type LocalEmbeddingDeps = {
+  createLocalProvider: (options: unknown) => Promise<EmbeddingProviderProduct["provider"]>;
+  formatLocalSetupError: (err: unknown) => string;
+};
+
+export function createLocalEmbeddingFactory(
+  deps: LocalEmbeddingDeps,
+): EmbeddingProviderFactory<unknown> {
+  return {
+    id: "local",
+    async create(options) {
+      const provider = await deps.createLocalProvider(options);
+      return { provider };
+    },
+    formatSetupError: deps.formatLocalSetupError,
+  };
+}
+
+/**
+ * The Abstract Factory registry. The string union appears here exactly
+ * once (in the keys); adding a new provider means adding one entry.
+ */
+export type EmbeddingProviderRegistry = ReadonlyMap<EmbeddingProviderId, EmbeddingProviderFactory>;
+
+export function createEmbeddingProviderRegistry(
+  localFactory: EmbeddingProviderFactory,
+): EmbeddingProviderRegistry {
+  return new Map<EmbeddingProviderId, EmbeddingProviderFactory>([
+    [openAiEmbeddingFactory.id, openAiEmbeddingFactory],
+    [geminiEmbeddingFactory.id, geminiEmbeddingFactory],
+    [voyageEmbeddingFactory.id, voyageEmbeddingFactory],
+    [localFactory.id, localFactory],
+  ]);
+}
+
+/**
+ * Named, documented `auto`-mode fallback order. The implicit array
+ * literal that used to live inside the loop is now a constant.
+ */
+export const AUTO_FALLBACK_ORDER: ReadonlyArray<Exclude<EmbeddingProviderId, "local">> = [
+  "openai",
+  "gemini",
+  "voyage",
+];

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -1,10 +1,17 @@
 import type { Llama, LlamaEmbeddingContext, LlamaModel } from "node-llama-cpp";
 import fsSync from "node:fs";
 import type { OpenClawConfig } from "../config/config.js";
+import type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
+import type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
+import type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
 import { resolveUserPath } from "../utils.js";
-import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
-import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
-import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
+import {
+  AUTO_FALLBACK_ORDER,
+  createEmbeddingProviderRegistry,
+  createLocalEmbeddingFactory,
+  type EmbeddingProviderId,
+  type EmbeddingProviderProduct,
+} from "./embedding-provider-factory.js";
 import { importNodeLlamaCpp } from "./node-llama.js";
 
 function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
@@ -125,31 +132,39 @@ async function createLocalEmbeddingProvider(
   };
 }
 
+// 630:P3 #63 -- the embeddings family lives in the Abstract Factory
+// registry (one factory per provider). createEmbeddingProvider keeps its
+// public signature; the body is now a registry lookup + the
+// AUTO_FALLBACK_ORDER walk, no provider-specific switch.
+const EMBEDDING_REGISTRY = createEmbeddingProviderRegistry(
+  createLocalEmbeddingFactory({
+    createLocalProvider: (options) =>
+      createLocalEmbeddingProvider(options as EmbeddingProviderOptions),
+    formatLocalSetupError,
+  }),
+);
+
+async function createWithFactory(
+  id: EmbeddingProviderId,
+  options: EmbeddingProviderOptions,
+): Promise<EmbeddingProviderProduct> {
+  const factory = EMBEDDING_REGISTRY.get(id);
+  if (!factory) {
+    throw new Error(`Unknown embeddings provider: ${id}`);
+  }
+  return factory.create(options);
+}
+
+function formatPrimaryEmbeddingError(err: unknown, provider: EmbeddingProviderId): string {
+  const factory = EMBEDDING_REGISTRY.get(provider);
+  return factory ? factory.formatSetupError(err) : formatError(err);
+}
+
 export async function createEmbeddingProvider(
   options: EmbeddingProviderOptions,
 ): Promise<EmbeddingProviderResult> {
   const requestedProvider = options.provider;
   const fallback = options.fallback;
-
-  const createProvider = async (id: "openai" | "local" | "gemini" | "voyage") => {
-    if (id === "local") {
-      const provider = await createLocalEmbeddingProvider(options);
-      return { provider };
-    }
-    if (id === "gemini") {
-      const { provider, client } = await createGeminiEmbeddingProvider(options);
-      return { provider, gemini: client };
-    }
-    if (id === "voyage") {
-      const { provider, client } = await createVoyageEmbeddingProvider(options);
-      return { provider, voyage: client };
-    }
-    const { provider, client } = await createOpenAiEmbeddingProvider(options);
-    return { provider, openAi: client };
-  };
-
-  const formatPrimaryError = (err: unknown, provider: "openai" | "local" | "gemini" | "voyage") =>
-    provider === "local" ? formatLocalSetupError(err) : formatError(err);
 
   if (requestedProvider === "auto") {
     const missingKeyErrors: string[] = [];
@@ -157,19 +172,19 @@ export async function createEmbeddingProvider(
 
     if (canAutoSelectLocal(options)) {
       try {
-        const local = await createProvider("local");
+        const local = await createWithFactory("local", options);
         return { ...local, requestedProvider };
       } catch (err) {
         localError = formatLocalSetupError(err);
       }
     }
 
-    for (const provider of ["openai", "gemini", "voyage"] as const) {
+    for (const provider of AUTO_FALLBACK_ORDER) {
       try {
-        const result = await createProvider(provider);
+        const result = await createWithFactory(provider, options);
         return { ...result, requestedProvider };
       } catch (err) {
-        const message = formatPrimaryError(err, provider);
+        const message = formatPrimaryEmbeddingError(err, provider);
         if (isMissingApiKeyError(err)) {
           missingKeyErrors.push(message);
           continue;
@@ -186,13 +201,13 @@ export async function createEmbeddingProvider(
   }
 
   try {
-    const primary = await createProvider(requestedProvider);
+    const primary = await createWithFactory(requestedProvider, options);
     return { ...primary, requestedProvider };
   } catch (primaryErr) {
-    const reason = formatPrimaryError(primaryErr, requestedProvider);
+    const reason = formatPrimaryEmbeddingError(primaryErr, requestedProvider);
     if (fallback && fallback !== "none" && fallback !== requestedProvider) {
       try {
-        const fallbackResult = await createProvider(fallback);
+        const fallbackResult = await createWithFactory(fallback, options);
         return {
           ...fallbackResult,
           requestedProvider,


### PR DESCRIPTION
## Summary

Closes #63.

The embeddings provider family used to live in five separate vocabularies inside `src/memory/embeddings.ts`:

1. the string union `"openai" | "local" | "gemini" | "voyage"`
2. the `createProvider` arrow function (one branch per id)
3. the `auto`-mode fallback array `["openai", "gemini", "voyage"]`
4. the `EmbeddingProviderResult` shape with optional fields per provider
5. the per-id `formatPrimaryError` selector

Adding a new provider was a textbook Shotgun Surgery edit -- new branch + new optional field + new fallback entry + new error formatter -- with no compiler enforcement.

This PR introduces an **Abstract Factory** (`EmbeddingProviderFactory`) and a registry (`createEmbeddingProviderRegistry`). Each factory owns its id, creation logic, and setup-error formatting in one place. The conditional ladder in `createEmbeddingProvider` becomes a registry lookup, and the auto-mode order becomes a named constant `AUTO_FALLBACK_ORDER`.

## Anti-pattern -> design pattern

| | |
|---|---|
| Anti-pattern | Shotgun Surgery |
| Pattern | **Abstract Factory** (Creational) |
| Files added | `src/memory/embedding-provider-factory.ts`, `src/memory/embedding-provider-factory.test.ts` |
| Files modified | `src/memory/embeddings.ts` (only `createEmbeddingProvider` body + imports) |
| LOC delta | +278 / -30 |

## What landed

```ts
type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage";

type EmbeddingProviderFactory = {
  readonly id: EmbeddingProviderId;
  create(options: unknown): Promise<EmbeddingProviderProduct>;
  formatSetupError(err: unknown): string;
};

const openAiEmbeddingFactory: EmbeddingProviderFactory;
const geminiEmbeddingFactory: EmbeddingProviderFactory;
const voyageEmbeddingFactory: EmbeddingProviderFactory;
function createLocalEmbeddingFactory(deps: LocalEmbeddingDeps): EmbeddingProviderFactory;

function createEmbeddingProviderRegistry(local): ReadonlyMap<EmbeddingProviderId, EmbeddingProviderFactory>;

const AUTO_FALLBACK_ORDER: ["openai", "gemini", "voyage"];  // local handled separately
```

`createEmbeddingProvider`'s body is now:

- `auto` mode: optional local attempt, then `for (const provider of AUTO_FALLBACK_ORDER) { registry.get(provider).create(options) }`
- explicit mode: `EMBEDDING_REGISTRY.get(requestedProvider).create(options)` plus the same fallback shape as before

The local factory uses dependency injection (`createLocalProvider`, `formatLocalSetupError`) so the new module stays node-llama-cpp-free; the verbose install hint and the lazy `node-llama-cpp` import remain in `embeddings.ts`.

## Why Abstract Factory (not Strategy or plain Factory Method)

Each embeddings provider is a *family* of related artifacts: a `provider` object (`embedQuery`, `embedBatch`), an SDK client (`openAi` / `gemini` / `voyage`), and an error-formatting style. A single `create(id)` method (Factory Method) would have to return a union and re-discriminate downstream. Strategy would model behavior selection but not co-vary the result shape with the id. Abstract Factory is the GoF answer: one interface that emits a *coordinated set of objects per family*, and a registry that picks the family.

## Verification

```
pnpm vitest run src/memory/embedding-provider-factory.test.ts src/memory/embeddings src/memory/embeddings-voyage.test.ts
> Test Files  3 passed (3)
> Tests       24 passed (24)
```

The 8 new factory tests cover:

- registry contains all four providers, exactly once each
- local factory delegates `create()` to the injected provider builder
- local factory delegates `formatSetupError()` to the injected formatter
- non-local factories use `Error.message` as the default formatter
- non-local factories stringify non-Error inputs
- `AUTO_FALLBACK_ORDER` excludes `local` and is the canonical 3-item array
- registry keys ARE the canonical id list (no other source of truth)
- a custom local factory can completely replace the default behavior

The 16 existing `embeddings.test.ts` + `embeddings-voyage.test.ts` cases pass unchanged, proving the registry rewrite preserves behavior end-to-end.

## Non-goals (carried over from the issue)

- Do not change the embeddings provider behavior, model defaults, or the on-disk vector schema.
- Do not change the public `createEmbeddingProvider` function signature.
- Do not refactor `manager.ts` consumers in this PR (a follow-up PR adopts the new tagged-result idea).
- Do not add new providers (Cohere, Bedrock) as part of this refactor.

## Scope

Medium (estimated 70-90 min in #63 backlog; actual ~80 min). One new file + one test file + a focused rewrite of one function body in `embeddings.ts`. The five vocabularies collapse to one (the registry).
